### PR TITLE
P8 swagger

### DIFF
--- a/database/DDL.sql
+++ b/database/DDL.sql
@@ -18,9 +18,43 @@ CREATE TABLE category(
 CREATE UNIQUE INDEX ux_category ON category(category) COMMENT 'Index único';
 CREATE UNIQUE INDEX ux_tag ON category(tag) COMMENT 'Index único';
 
+-- Producto
+CREATE TABLE product(
+    product_id INT NOT NULL AUTO_INCREMENT COMMENT 'Identificador único del producto',
+    gtin CHAR(13) NOT NULL COMMENT 'Código GTIN del producto',
+    product VARCHAR(100) NOT NULL COMMENT 'Nombre del producto',
+    description TEXT COMMENT 'Descripción del producto',
+    price FLOAT NOT NULL COMMENT 'Precio del producto',
+    stock INT NOT NULL COMMENT 'Cantidad en stock',
+    category_id INT NOT NULL COMMENT 'Identificador de la categoría',
+    status TINYINT NOT NULL COMMENT 'Estado del producto',
+    PRIMARY KEY (product_id) COMMENT 'Llave primaria de la tabla',
+    CONSTRAINT fk_product_category FOREIGN KEY (category_id) REFERENCES category(category_id)
+) COMMENT = 'Tabla que contiene los productos registrados';
+
+-- Constraints de producto
+CREATE UNIQUE INDEX ux_product_gtin ON product(gtin) COMMENT 'Index único para GTIN';
+CREATE UNIQUE INDEX ux_product_product ON product(product) COMMENT 'Index único para nombre de producto';
+
+-- Imagen de producto
+CREATE TABLE product_image(
+    product_image_id INT NOT NULL AUTO_INCREMENT COMMENT 'Identificador único de la imagen del producto',
+    product_id INT NOT NULL COMMENT 'Identificador del producto',
+    image VARCHAR(255) NOT NULL COMMENT 'Ruta de la imagen',
+    status TINYINT NOT NULL COMMENT 'Estado de la imagen',
+    PRIMARY KEY (product_image_id) COMMENT 'Llave primaria de la tabla',
+    CONSTRAINT fk_product_image_product FOREIGN KEY (product_id) REFERENCES product(product_id)
+) COMMENT = 'Tabla que contiene las imágenes de los productos';
+
 -- Simulación DML --
 -- INSERT INTO category (category, tag, status)
 -- VALUES 
 -- ('Mexicana', 'mx', '1'),
 -- ('Italiana', 'it', '0'),
 -- ('Japonesa', 'jp', '1');
+
+-- INSERT INTO product (gtin, product, description, price, stock, category_id, status)
+-- VALUES 
+-- ('7501234567890', 'Tacos al Pastor', 'Deliciosos tacos de carne al pastor con piña', 45.00, 100, 1, 1),
+-- ('7501234567891', 'Pizza Margarita', 'Pizza italiana con tomate, mozzarella y albahaca', 120.00, 50, 2, 1),
+-- ('7501234567892', 'Sushi Roll', 'Rollo de sushi con salmón y aguacate', 85.00, 75, 3, 1);

--- a/src/main/java/com/commons/mapper/MapperProduct.java
+++ b/src/main/java/com/commons/mapper/MapperProduct.java
@@ -9,9 +9,22 @@ import com.product.api.dto.in.DtoProductIn;
 import com.product.api.dto.out.DtoProductListOut;
 import com.product.api.entity.Product;
 
+/**
+ * Clase de soporte de servicio encargada de la conversión de estructuras
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 @Service
 public class MapperProduct {
 	
+	/**
+	 * Convierte una lista de entidades de productos a una lista de productos como objetos de transferencia
+	 * @param products lista de entidades de productos
+	 * @return Una lista de objetos de transferencia
+	 */
 	public List<DtoProductListOut> fromProductList(List<Product> products){
 		List<DtoProductListOut> list = new ArrayList<>();
 		for(Product product: products) {
@@ -26,6 +39,11 @@ public class MapperProduct {
 		return list;
 	}
 
+	/**
+	 * Convierte una lista de productos como objetos de transferencia a una lista de entidades de productos
+	 * @param products lista de productos como objetos de transferencia
+	 * @return Una lista de entidades de productos
+	 */
 	public Product fromDto(DtoProductIn dto) {
 		Product product = new Product();
 		product.setGtin(dto.getGtin());
@@ -39,6 +57,12 @@ public class MapperProduct {
         return product;
 	}
 	
+	/**
+	 * Crea una entidad producto desde un productos como objetos de transferencia
+	 * @param id identificador a establecer al producto
+	 * @param dto producto como objeto de transferencia
+	 * @return Una entidad producto con la información brindada
+	 */
 	public Product fromDto(Integer id, DtoProductIn dto) {
 		Product product = fromDto(dto);
 		product.setProduct_id(id);

--- a/src/main/java/com/commons/mapper/MapperProduct.java
+++ b/src/main/java/com/commons/mapper/MapperProduct.java
@@ -1,0 +1,48 @@
+package com.commons.mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.product.api.dto.in.DtoProductIn;
+import com.product.api.dto.out.DtoProductListOut;
+import com.product.api.entity.Product;
+
+@Service
+public class MapperProduct {
+	
+	public List<DtoProductListOut> fromProductList(List<Product> products){
+		List<DtoProductListOut> list = new ArrayList<>();
+		for(Product product: products) {
+			list.add(new DtoProductListOut(
+					product.getProduct_id(),
+					product.getGtin(),
+					product.getProduct(),
+					product.getPrice(),
+					product.getStatus()
+					));
+		}
+		return list;
+	}
+
+	public Product fromDto(DtoProductIn dto) {
+		Product product = new Product();
+		product.setGtin(dto.getGtin());
+		product.setProduct(dto.getProduct());
+		product.setDescription(dto.getDescription());
+		product.setPrice(dto.getPrice());
+		product.setStock(dto.getStock());
+		product.setCategory_id(dto.getCategory_id());
+		product.setStatus(1);
+        
+        return product;
+	}
+	
+	public Product fromDto(Integer id, DtoProductIn dto) {
+		Product product = fromDto(dto);
+		product.setProduct_id(id);
+		return product;
+	}
+	
+}

--- a/src/main/java/com/product/ProductApplication.java
+++ b/src/main/java/com/product/ProductApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 /**
  * Aplicación Spring
  */
-@SpringBootApplication(scanBasePackages={"com.product"})
+@SpringBootApplication(scanBasePackages={"com.product", "com.commons"})
 public class ProductApplication {
 
 	/**

--- a/src/main/java/com/product/api/controller/CtrlCategory.java
+++ b/src/main/java/com/product/api/controller/CtrlCategory.java
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 /**
- * Controlador para producto
+ * Controlador para categoría
  * 
  * @author Isaac Robledo R
  * @author Alejandro Sánchez E
@@ -37,7 +37,7 @@ import jakarta.validation.Valid;
  * @docsTag
  * @beta
  */
-@Tag(name = "Product", description = "Endpoints para productos")
+@Tag(name = "Category", description = "Endpoints relacionados con las categorías de productos")
 @RestController
 @RequestMapping("/category")
 public class CtrlCategory {
@@ -92,7 +92,7 @@ public class CtrlCategory {
             content = { @Content(
                     array = @ArraySchema(schema = @Schema(implementation = Category.class)),
                     mediaType = "aplication/json",
-                    examples = @ExampleObject(value = "{\"category\": \"Mexicana\", \"tag\": \"MX\", \"status\": 1, \"categoryid\": \"3\"}")
+                    examples = @ExampleObject(value = "{\"category\": \"Mexicana\", \"tag\": \"MX\", \"status\": 1, \"categoryid\": 3}")
             )}
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))

--- a/src/main/java/com/product/api/controller/CtrlCategory.java
+++ b/src/main/java/com/product/api/controller/CtrlCategory.java
@@ -1,0 +1,190 @@
+package com.product.api.controller;
+
+import com.commons.dto.ApiResponse;
+import com.product.api.dto.in.DtoCategoryIn;
+import com.product.api.entity.Category;
+import com.product.api.service.SvcCategory;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+
+/**
+ * Controlador para producto
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.5.0
+ * @docsTag
+ * @beta
+ */
+@Tag(name = "Product", description = "Endpoints para productos")
+@RestController
+@RequestMapping("/category")
+public class CtrlCategory {
+    
+    /**
+     * Clase de servicio para categorías.
+     */
+    @Autowired
+    SvcCategory svc;
+
+    /**
+     * Constructor de la clase
+     * Vacío
+     */
+    public CtrlCategory() {}
+    
+    /**
+     * Regresa la lista de categorías disponible
+     * @return La lista de categorías disponible
+     * @mapeo /category
+     * @metodoHTTP GET
+     * @estado 200 - Operación realizada con éxito
+     * @estado 400 - Ocurrió un error inesperado
+     */
+    @Operation(summary = "Obtiene todas las categorías", description = "Regresa las categorías registradas")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
+            content = { @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = Category.class)),
+                    mediaType = "aplication/json",
+                    examples = @ExampleObject(value = "{\"category\": \"Mexicana\", \"tag\": \"MX\", \"status\": 0, \"categoryid\": \"3\"}")
+            )}
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
+    })
+    @GetMapping
+    public ResponseEntity<List<Category>> getCategories() {
+        return ResponseEntity.ok(svc.findAll());
+    }
+
+    /**
+     * Regresa la lista de categorías disponible
+     * @return La lista de categorías disponible
+     * @mapeo /category/active
+     * @metodoHTTP GET
+     * @estado 200 - Operación realizada con éxito
+     * @estado 400 - Ocurrió un error inesperado
+     */
+    @Operation(summary = "Obtiene todas las categorías activas", description = "Regresa las categorías registradas con estado activo (1)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
+            content = { @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = Category.class)),
+                    mediaType = "aplication/json",
+                    examples = @ExampleObject(value = "{\"category\": \"Mexicana\", \"tag\": \"MX\", \"status\": 1, \"categoryid\": \"3\"}")
+            )}
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
+    })
+    @GetMapping("/active")
+    public ResponseEntity<List<Category>> findActive(){
+        return ResponseEntity.ok(svc.findActive());
+    }
+
+    /**
+     * Crea una categoría
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /category
+     * @metodoHTTP POST
+     * @estado 200 - La categoría ha sido registrada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 409 - Nombre de la categoría repetida
+     * @estado 409 - Etiqueta de la categoría repetida
+     */
+    @Operation(summary = "Registra una categoría", description = "Crea y agrega una categoría, con id único y activa por defecto")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido registrada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido registrada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Nombre de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El nombre de la categoría ya está registrado"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Etiqueta de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El tag de la categoría ya está registrado")))
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse> create(@Valid @RequestBody DtoCategoryIn in){
+        return ResponseEntity.ok(svc.create(in));
+    }
+
+    /**
+     * Actualiza los datos de una categoría
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /category/{id}
+     * @metodoHTTP PUT
+     * @estado 200 - La categoría ha sido actualizada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - ID no encontrado
+     * @estado 409 - Nombre de la categoría repetida
+     * @estado 409 - Etiqueta de la categoría repetida
+     */
+    @Operation(summary = "Actualiza una categoría", description = "Actualiza los datos de una categoría")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido actualizada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido actualizada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de la categoría no existe"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Nombre de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El nombre de la categoría ya está registrado"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Etiqueta de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El tag de la categoría ya está registrado")))
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse> update(@Valid @RequestBody DtoCategoryIn in, @PathVariable("id") Integer id){
+        return ResponseEntity.ok(svc.update(in, id));
+    }
+
+    /**
+     * Habilita una categoría
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /category/{id}/enable
+     * @metodoHTTP PATCH
+     * @estado 200 - La categoría ha sido activada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - ID no encontrado
+     */
+    @Operation(summary = "Habilita una categoría", description = "Cambia el estado de una categoría a activo (1)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido activada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido activada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de la categoría no existe")))
+    })
+    @PatchMapping("/{id}/enable")
+    public ResponseEntity<ApiResponse> enable(@PathVariable Integer id) {
+        return ResponseEntity.ok(svc.enable(id));
+    }
+
+    /**
+     * Deshabilita una categoría
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /category/{id}/disable
+     * @metodoHTTP PATCH
+     * @estado 200 - La categoría ha sido desactivada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - ID no encontrado
+     */
+    @Operation(summary = "Deshabilita una categoría", description = "Cambia el estado de una categoría a desactivado (0)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido desactivada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido desactivada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de la categoría no existe")))
+    })
+    @PatchMapping("/{id}/disable")
+    public ResponseEntity<ApiResponse> disable(@PathVariable Integer id) {
+        return ResponseEntity.ok(svc.disable(id));
+    }
+}

--- a/src/main/java/com/product/api/controller/CtrlCategory.java
+++ b/src/main/java/com/product/api/controller/CtrlCategory.java
@@ -41,7 +41,7 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping("/category")
 public class CtrlCategory {
-    
+
     /**
      * Clase de servicio para categorías.
      */
@@ -104,6 +104,7 @@ public class CtrlCategory {
 
     /**
      * Crea una categoría
+     * @param in objeto de transferencia de entrada que representa una categoría (body)
      * @return Una respuesta de éxito o fallo
      * @mapeo /category
      * @metodoHTTP POST
@@ -126,6 +127,8 @@ public class CtrlCategory {
 
     /**
      * Actualiza los datos de una categoría
+     * @param in objeto de transferencia de entrada que representa una categoría (body)
+     * @param id identificador de la categoría (visto en el path)
      * @return Una respuesta de éxito o fallo
      * @mapeo /category/{id}
      * @metodoHTTP PUT
@@ -150,6 +153,7 @@ public class CtrlCategory {
 
     /**
      * Habilita una categoría
+     * @param id identificador de la categoría (visto en el path)
      * @return Una respuesta de éxito o fallo
      * @mapeo /category/{id}/enable
      * @metodoHTTP PATCH
@@ -170,6 +174,7 @@ public class CtrlCategory {
 
     /**
      * Deshabilita una categoría
+     * @param id identificador de la categoría (visto en el path)
      * @return Una respuesta de éxito o fallo
      * @mapeo /category/{id}/disable
      * @metodoHTTP PATCH

--- a/src/main/java/com/product/api/controller/CtrlProduct.java
+++ b/src/main/java/com/product/api/controller/CtrlProduct.java
@@ -1,14 +1,11 @@
 package com.product.api.controller;
 
-import com.product.api.dto.DtoCategoryIn;
-import com.product.api.entity.Category;
-import com.product.api.service.SvcCategory;
-import com.commons.dto.ApiResponse;
-
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,175 +15,49 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.commons.dto.ApiResponse;
+import com.product.api.dto.in.DtoProductIn;
+import com.product.api.dto.out.DtoProductListOut;
+import com.product.api.dto.out.DtoProductOut;
+import com.product.api.service.SvcProduct;
+import com.product.exception.ApiException;
 
 import jakarta.validation.Valid;
 
-/**
- * Controlador para producto
- * 
- * @author Isaac Robledo R
- * @author Alejandro Sánchez E
- * @version 0.5.0
- * @docsTag
- * @beta
- */
-@Tag(name = "Product", description = "Endpoints para productos")
 @RestController
-@RequestMapping("/category")
+@RequestMapping("/product")
 public class CtrlProduct {
-    
-    /**
-     * Clase de servicio para categorías.
-     */
-    @Autowired
-    SvcCategory svc;
 
-    /**
-     * Constructor de la clase
-     * Vacío
-     */
-    public CtrlProduct() {}
-    
-    /**
-     * Regresa la lista de categorías disponible
-     * @return La lista de categorías disponible
-     * @mapeo /category
-     * @metodoHTTP GET
-     * @estado 200 - Operación realizada con éxito
-     * @estado 400 - Ocurrió un error inesperado
-     */
-    @Operation(summary = "Obtiene todas las categorías", description = "Regresa las categorías registradas")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
-            content = { @Content(
-                    array = @ArraySchema(schema = @Schema(implementation = Category.class)),
-                    mediaType = "aplication/json",
-                    examples = @ExampleObject(value = "{\"category\": \"Mexicana\", \"tag\": \"MX\", \"status\": 0, \"categoryid\": \"3\"}")
-            )}
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
-    })
-    @GetMapping
-    public ResponseEntity<List<Category>> getCategories() {
-        return ResponseEntity.ok(svc.findAll());
-    }
+	@Autowired
+	SvcProduct svc;
 
-    /**
-     * Regresa la lista de categorías disponible
-     * @return La lista de categorías disponible
-     * @mapeo /category/active
-     * @metodoHTTP GET
-     * @estado 200 - Operación realizada con éxito
-     * @estado 400 - Ocurrió un error inesperado
-     */
-    @Operation(summary = "Obtiene todas las categorías activas", description = "Regresa las categorías registradas con estado activo (1)")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
-            content = { @Content(
-                    array = @ArraySchema(schema = @Schema(implementation = Category.class)),
-                    mediaType = "aplication/json",
-                    examples = @ExampleObject(value = "{\"category\": \"Mexicana\", \"tag\": \"MX\", \"status\": 1, \"categoryid\": \"3\"}")
-            )}
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
-    })
-    @GetMapping("/active")
-    public ResponseEntity<List<Category>> findActive(){
-        return ResponseEntity.ok(svc.findActive());
-    }
+	@GetMapping
+	public ResponseEntity<List<DtoProductListOut>> getProducts() {
+		return svc.getProducts();
+	}
 
-    /**
-     * Crea una categoría
-     * @return Una respuesta de éxito o fallo
-     * @mapeo /category
-     * @metodoHTTP POST
-     * @estado 200 - La categoría ha sido registrada
-     * @estado 400 - Ocurrió un error inesperado
-     * @estado 409 - Nombre de la categoría repetida
-     * @estado 409 - Etiqueta de la categoría repetida
-     */
-    @Operation(summary = "Registra una categoría", description = "Crea y agrega una categoría, con id único y activa por defecto")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido registrada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido registrada"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Nombre de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El nombre de la categoría ya está registrado"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Etiqueta de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El tag de la categoría ya está registrado")))
-    })
-    @PostMapping
-    public ResponseEntity<ApiResponse> create(@Valid @RequestBody DtoCategoryIn in){
-        return ResponseEntity.ok(svc.create(in));
-    }
+	@GetMapping("/{id}")
+	public ResponseEntity<DtoProductOut> getProduct(@PathVariable Integer id) {
+		return svc.getProduct(id);
+	}
 
-    /**
-     * Actualiza los datos de una categoría
-     * @return Una respuesta de éxito o fallo
-     * @mapeo /category/{id}
-     * @metodoHTTP PUT
-     * @estado 200 - La categoría ha sido actualizada
-     * @estado 400 - Ocurrió un error inesperado
-     * @estado 404 - ID no encontrado
-     * @estado 409 - Nombre de la categoría repetida
-     * @estado 409 - Etiqueta de la categoría repetida
-     */
-    @Operation(summary = "Actualiza una categoría", description = "Actualiza los datos de una categoría")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido actualizada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido actualizada"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de la categoría no existe"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Nombre de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El nombre de la categoría ya está registrado"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Etiqueta de la categoría repetida", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El tag de la categoría ya está registrado")))
-    })
-    @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse> update(@Valid @RequestBody DtoCategoryIn in, @PathVariable("id") Integer id){
-        return ResponseEntity.ok(svc.update(in, id));
-    }
+	@PostMapping
+	public ResponseEntity<ApiResponse> createProduct(@Valid @RequestBody DtoProductIn in) {
+		return svc.createProduct(in);
+	}
 
-    /**
-     * Habilita una categoría
-     * @return Una respuesta de éxito o fallo
-     * @mapeo /category/{id}/enable
-     * @metodoHTTP PATCH
-     * @estado 200 - La categoría ha sido activada
-     * @estado 400 - Ocurrió un error inesperado
-     * @estado 404 - ID no encontrado
-     */
-    @Operation(summary = "Habilita una categoría", description = "Cambia el estado de una categoría a activo (1)")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido activada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido activada"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de la categoría no existe")))
-    })
-    @PatchMapping("/{id}/enable")
-    public ResponseEntity<ApiResponse> enable(@PathVariable Integer id) {
-        return ResponseEntity.ok(svc.enable(id));
-    }
+	@PutMapping("/{id}")
+	public ResponseEntity<ApiResponse> updateProduct(@PathVariable Integer id, @Valid @RequestBody DtoProductIn in) {
+		return svc.updateProduct(id, in);
+	}
 
-    /**
-     * Deshabilita una categoría
-     * @return Una respuesta de éxito o fallo
-     * @mapeo /category/{id}/disable
-     * @metodoHTTP PATCH
-     * @estado 200 - La categoría ha sido desactivada
-     * @estado 400 - Ocurrió un error inesperado
-     * @estado 404 - ID no encontrado
-     */
-    @Operation(summary = "Deshabilita una categoría", description = "Cambia el estado de una categoría a desactivado (0)")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La categoría ha sido desactivada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido desactivada"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de la categoría no existe")))
-    })
-    @PatchMapping("/{id}/disable")
-    public ResponseEntity<ApiResponse> disable(@PathVariable Integer id) {
-        return ResponseEntity.ok(svc.disable(id));
-    }
+	@PatchMapping("/{id}/enable")
+	public ResponseEntity<ApiResponse> enableProduct(@PathVariable Integer id) {
+		return svc.enableProduct(id);
+	}
 
-
+	@PatchMapping("/{id}/disable")
+	public ResponseEntity<ApiResponse> disableProduct(@PathVariable Integer id) {
+		return svc.disableProduct(id);
+	}
 }

--- a/src/main/java/com/product/api/controller/CtrlProduct.java
+++ b/src/main/java/com/product/api/controller/CtrlProduct.java
@@ -19,43 +19,171 @@ import com.commons.dto.ApiResponse;
 import com.product.api.dto.in.DtoProductIn;
 import com.product.api.dto.out.DtoProductListOut;
 import com.product.api.dto.out.DtoProductOut;
+import com.product.api.entity.Category;
+import com.product.api.entity.Product;
 import com.product.api.service.SvcProduct;
 import com.product.exception.ApiException;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
+/**
+ * Controlador para producto
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @docsTag
+ * @beta
+ */
+@Tag(name = "Product", description = "Endpoints relacionados con los productos")
 @RestController
 @RequestMapping("/product")
 public class CtrlProduct {
 
+	/**
+	 * Clase de servicio para productos
+	 */
 	@Autowired
 	SvcProduct svc;
 
+	/**
+	 * Regresa la lista de prodcutos
+	 * @return La lista de productos
+	 * @mapeo /product
+	 * @metodoHTTP GET
+	 * @estado 200 - Operación realizada con éxito
+	 * @estado 400 - Ocurrió un error inesperado
+	 */
+	@Operation(summary = "Obtiene todos los productos", description = "Regresa los productos registradas")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
+            content = { @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = Product.class)),
+                    mediaType = "aplication/json",
+                    examples = @ExampleObject(value = "{\"product_id\": 1, \"gtin\": 7501428800778, \"description\": \"Limpiador de pizarrones\", \"price\": 59.99, \"stock\": 16, \"category_id\": 3, \"status\": 1}")
+            )}
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
+    })
 	@GetMapping
 	public ResponseEntity<List<DtoProductListOut>> getProducts() {
 		return svc.getProducts();
 	}
 
+	/**
+	 * Regresa la información del producto buscado
+	 * @return La información del producto buscado
+	 * @mapeo /product/{id}
+	 * @metodoHTTP GET
+	 * @estado 200 - Operación realizada con éxito
+	 * @estado 400 - Ocurrió un error inesperado
+	 * @estado 404 - ID no encontrado
+	 */
+	@Operation(summary = "Obtiene un producto", description = "Regresa el producto registrado con el identificador brindado")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
+            content = { @Content(
+                    schema = @Schema(implementation = Product.class),
+                    mediaType = "aplication/json",
+                    examples = @ExampleObject(value = "{\"product_id\": 1, \"gtin\": 7501428800778, \"description\": \"Limpiador de pizarrones\", \"price\": 59.99, \"stock\": 16, \"category_id\": 3, \"status\": 1}")
+            )}
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "ID no encontrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id del producto no existe")))
+    })
 	@GetMapping("/{id}")
 	public ResponseEntity<DtoProductOut> getProduct(@PathVariable Integer id) {
 		return svc.getProduct(id);
 	}
 
+	/**
+     * Crea un producto
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /product
+     * @metodoHTTP POST
+     * @estado 200 - El producto ha sido registrado
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 409 - Un dato ingresado ha sido detectado con algún error
+     */
+	@Operation(summary = "Registra un producto", description = "Crea y agrega un producto con id único")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "El producto ha sido registrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido registrada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id de categoría no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de categoría no existe"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "El gtin del producto ya está registrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El gtin del producto ya está registrado"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "El nombre del producto ya está registrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El nombre del producto ya está registrado")))
+    })
 	@PostMapping
 	public ResponseEntity<ApiResponse> createProduct(@Valid @RequestBody DtoProductIn in) {
 		return svc.createProduct(in);
 	}
 
+	/**
+     * Actualiza los datos de un producto
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /product/{id}
+     * @metodoHTTP PUT
+     * @estado 200 - El producto ha sido actualizado
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - ID no encontrado
+     * @estado 409 - Un dato ingresado ha sido detectado con algún error
+     */
+	@Operation(summary = "Actualiza un producto", description = "Actualiza los datos de un producto")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "El producto ha sido actualizado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido actualizada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id del producto no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id del producto no existe"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id de categoría no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id de categoría no existe"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "El gtin del producto ya está registrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El gtin del producto ya está registrado"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "El nombre del producto ya está registrado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El nombre del producto ya está registrado")))
+    })
 	@PutMapping("/{id}")
 	public ResponseEntity<ApiResponse> updateProduct(@PathVariable Integer id, @Valid @RequestBody DtoProductIn in) {
 		return svc.updateProduct(id, in);
 	}
 
+    /**
+     * Habilita un producto
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /product/{id}/enable
+     * @metodoHTTP PATCH
+     * @estado 200 - La categoría ha sido activada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - ID no encontrado
+     */
+	@Operation(summary = "Habilita un producto", description = "Cambia el estado de un producto a activo (1)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "El producto ha sido activado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El producto ha sido activado"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id del producto no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id del producto no existe"))),
+    })
 	@PatchMapping("/{id}/enable")
 	public ResponseEntity<ApiResponse> enableProduct(@PathVariable Integer id) {
 		return svc.enableProduct(id);
 	}
 
+	/**
+     * Deshabilita un producto
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /product/{id}/disable
+     * @metodoHTTP PATCH
+     * @estado 200 - La categoría ha sido desactivada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - ID no encontrado
+     */
+	@Operation(summary = "Deshabilita un producto", description = "Cambia el estado de un producto a desactivado (0)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "El producto ha sido desactivado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El producto ha sido desactivado"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id del producto no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id del producto no existe"))),
+    })
 	@PatchMapping("/{id}/disable")
 	public ResponseEntity<ApiResponse> disableProduct(@PathVariable Integer id) {
 		return svc.disableProduct(id);

--- a/src/main/java/com/product/api/controller/CtrlProduct.java
+++ b/src/main/java/com/product/api/controller/CtrlProduct.java
@@ -79,6 +79,7 @@ public class CtrlProduct {
 
 	/**
 	 * Regresa la información del producto buscado
+     * @param id identificador del producto (visto en el path)
 	 * @return La información del producto buscado
 	 * @mapeo /product/{id}
 	 * @metodoHTTP GET
@@ -105,6 +106,7 @@ public class CtrlProduct {
 
 	/**
      * Crea un producto
+     * @param in objeto de transferencia de entrada que representa un producto (body)
      * @return Una respuesta de éxito o fallo
      * @mapeo /product
      * @metodoHTTP POST
@@ -127,6 +129,8 @@ public class CtrlProduct {
 
 	/**
      * Actualiza los datos de un producto
+     * @param id identificador del producto (visto en el path)
+     * @param in objeto de transferencia de entrada que representa un producto (body)
      * @return Una respuesta de éxito o fallo
      * @mapeo /product/{id}
      * @metodoHTTP PUT
@@ -151,6 +155,7 @@ public class CtrlProduct {
 
     /**
      * Habilita un producto
+     * @param id identificador del producto (visto en el path)
      * @return Una respuesta de éxito o fallo
      * @mapeo /product/{id}/enable
      * @metodoHTTP PATCH
@@ -171,6 +176,7 @@ public class CtrlProduct {
 
 	/**
      * Deshabilita un producto
+     * @param id identificador del producto (visto en el path)
      * @return Una respuesta de éxito o fallo
      * @mapeo /product/{id}/disable
      * @metodoHTTP PATCH

--- a/src/main/java/com/product/api/controller/CtrlProductImage.java
+++ b/src/main/java/com/product/api/controller/CtrlProductImage.java
@@ -1,0 +1,119 @@
+package com.product.api.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.commons.dto.ApiResponse;
+import com.product.api.dto.in.DtoProductImageIn;
+import com.product.api.entity.ProductImage;
+import com.product.api.service.SvcProductImage;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+/**
+ * Controlador para imagenes de producto
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @docsTag
+ * @beta
+ */
+@Tag(name = "Product-Image", description = "Endpoints relacionados con las imagenes de los productos")
+@RestController
+@RequestMapping("/product/{id}/image")
+public class CtrlProductImage {
+
+    /**
+     * Clase de servicio para imagenes de producto
+     */
+    @Autowired
+    SvcProductImage svc;
+
+    /**
+     * Regresa la lista de imagenes de un producto disponible
+     * @return La lista de imagenes de un producto disponible
+     * @mapeo /product/{id}/image
+     * @metodoHTTP GET
+     * @estado 200 - Operación realizada con éxito
+     * @estado 400 - Ocurrió un error inesperado
+     */
+    @Operation(summary = "Obtiene todas las imagenes de un producto", description = "Regresa las imagenes registradas asociadas a un producto específico")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Operación realizada con éxito", 
+            content = { @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = ProductImage.class)),
+                    mediaType = "aplication/json",
+                    examples = @ExampleObject(value = "{\"product_image_id\": 1, \"product_id\": 2, \"status\": 0, \"image\": \"92489398420...\"}")
+            )}
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse> getProductImages(@PathVariable Integer id) {
+        return ResponseEntity.ok(svc.findAll(id));
+    }
+    
+    /**
+     * Crea una imagen para un producto
+     * @param id identificador del producto al que se asociará la imagen
+     * @param in objeto de transferencia de entrada que representa una imagen de producto (body)
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /product/{id}/image
+     * @metodoHTTP POST
+     * @estado 200 - La categoría ha sido registrada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - El id del producto no existeó
+     * @estado 409 - 
+     */
+    @Operation(summary = "Registra una categoría", description = "Crea y agrega una categoría, con id único y activa por defecto")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La imagen ha sido registrada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido registrada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id del producto no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id del producto no existe"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "")))
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse> createProductImage(@PathVariable Integer id, @Valid @RequestBody DtoProductImageIn in){
+        return ResponseEntity.ok(svc.upload(in));
+    }
+
+    /**
+     * Elimina una imagen para un producto
+     * @param id identificador del producto al del que se eliminará la imagen
+     * @param product_image_id identificador del producto al del que se eliminará la imagen
+     * @return Una respuesta de éxito o fallo
+     * @mapeo /product/{id}/image/{product-image-id}
+     * @metodoHTTP POST
+     * @estado 200 - La categoría ha sido registrada
+     * @estado 400 - Ocurrió un error inesperado
+     * @estado 404 - El id del producto no existeó
+     * @estado 409 - 
+     */
+    @Operation(summary = "Registra una categoría", description = "Crea y agrega una categoría, con id único y activa por defecto")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "La imagen ha sido eliminada", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "La categoría ha sido registrada"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error inesperado", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "El id del producto no existe", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "El id del producto no existe"))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"), examples = @ExampleObject(value = "")))
+    })
+    @DeleteMapping("/{product-image-id}")
+    public ResponseEntity<ApiResponse> deleteProductImage(@PathVariable Integer id, @PathVariable("product-image-id") Integer product_image_id) {
+        return ResponseEntity.ok(svc.delete(id, product_image_id));
+    }
+
+}

--- a/src/main/java/com/product/api/controller/CtrlProductImage.java
+++ b/src/main/java/com/product/api/controller/CtrlProductImage.java
@@ -1,5 +1,7 @@
 package com.product.api.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -64,7 +66,7 @@ public class CtrlProductImage {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Ocurrió un error de conexión", content = @Content(mediaType = "text/plain", schema = @Schema(type = "string")))
     })
     @GetMapping
-    public ResponseEntity<ApiResponse> getProductImages(@PathVariable Integer id) {
+    public ResponseEntity<List<ProductImage>> getProductImages(@PathVariable Integer id) {
         return ResponseEntity.ok(svc.findAll(id));
     }
     

--- a/src/main/java/com/product/api/dto/in/DtoCategoryIn.java
+++ b/src/main/java/com/product/api/dto/in/DtoCategoryIn.java
@@ -1,4 +1,4 @@
-package com.product.api.dto;
+package com.product.api.dto.in;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/product/api/dto/in/DtoCategoryIn.java
+++ b/src/main/java/com/product/api/dto/in/DtoCategoryIn.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
 /**
- * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a categorías
+ * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a la entrada de datos de categorías
  * 
  * @author Isaac Robledo R
  * @author Alejandro Sánchez E

--- a/src/main/java/com/product/api/dto/in/DtoProductImageIn.java
+++ b/src/main/java/com/product/api/dto/in/DtoProductImageIn.java
@@ -16,9 +16,9 @@ public class DtoProductImageIn {
     /**
      * Identificador de la imagen de un producto
      */
-    @JsonProperty("product_image_id")
-	@NotNull(message="El identificador de la imagen de producto es obligatorio")
-    private Integer productImageId;
+    @JsonProperty("product_id")
+	@NotNull(message="El identificador de producto es obligatorio")
+    private Integer productId;
 
     /**
      * Imagen de producto
@@ -28,19 +28,19 @@ public class DtoProductImageIn {
     private String image;
 
     /**
-     * Regresa un identificador de la imagen del producto
-     * @return un identificador de la imagen del producto
+     * Regresa un identificador del producto
+     * @return un identificador del producto
      */
-    public Integer getProductImage_id() {
-        return productImageId;
+    public Integer getProduct_id() {
+        return productId;
     }
 
     /**
-     * Actualiza el identificador de la imagen de producto
-     * @param productImageId identificador de la imagen de producto
+     * Actualiza el identificador del producto
+     * @param productId identificador del producto
      */
-    public void setProductImage_id(Integer productImageId) {
-        this.productImageId = productImageId;
+    public void setProductImage_id(Integer productId) {
+        this.productId = productId;
     }
 
     /**
@@ -53,7 +53,7 @@ public class DtoProductImageIn {
 
     /**
      * Actualiza la imagen de producto
-     * @param productImageId imagen de producto
+     * @param image imagen de producto
      */
     public void setImage(String image) {
         this.image = image;

--- a/src/main/java/com/product/api/dto/in/DtoProductImageIn.java
+++ b/src/main/java/com/product/api/dto/in/DtoProductImageIn.java
@@ -1,0 +1,61 @@
+package com.product.api.dto.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.NotNull;
+/**
+ * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a la entrada de datos de las imagenes de un producto
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
+public class DtoProductImageIn {
+
+    /**
+     * Identificador de la imagen de un producto
+     */
+    @JsonProperty("product_image_id")
+	@NotNull(message="El identificador de la imagen de producto es obligatorio")
+    private Integer productImageId;
+
+    /**
+     * Imagen de producto
+     */
+    @JsonProperty("image")
+    @NotNull(message="La imagen es obligatoria")
+    private String image;
+
+    /**
+     * Regresa un identificador de la imagen del producto
+     * @return un identificador de la imagen del producto
+     */
+    public Integer getProductImage_id() {
+        return productImageId;
+    }
+
+    /**
+     * Actualiza el identificador de la imagen de producto
+     * @param productImageId identificador de la imagen de producto
+     */
+    public void setProductImage_id(Integer productImageId) {
+        this.productImageId = productImageId;
+    }
+
+    /**
+     * Regresa la imagen de producto
+     * @return la imagen de producto
+     */
+    public String getImage() {
+        return image;
+    }
+
+    /**
+     * Actualiza la imagen de producto
+     * @param productImageId imagen de producto
+     */
+    public void setImage(String image) {
+        this.image = image;
+    }
+}

--- a/src/main/java/com/product/api/dto/in/DtoProductIn.java
+++ b/src/main/java/com/product/api/dto/in/DtoProductIn.java
@@ -1,0 +1,84 @@
+package com.product.api.dto.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class DtoProductIn {
+
+	@JsonProperty("gtin")
+	@Pattern(regexp = "^\\+?\\d{13}$", message = "El gtin tiene un formato inválido")
+	@NotNull(message="El gtin es obligatorio")
+	private String gtin;
+	
+	@JsonProperty("product")
+	@NotNull(message="El product es obligatorio")
+	private String product;
+	
+	@JsonProperty("description")
+	@NotNull(message="El description es obligatorio")
+	private String description;
+	
+	@JsonProperty("price")
+	@Min(value = 0)
+	@NotNull(message="El price es obligatorio")
+	private Float price;
+	
+	@JsonProperty("stock")
+	@NotNull(message="El stock es obligatorio")
+	private Integer stock;
+
+	@JsonProperty("category_id")
+	@NotNull(message="El category_id es obligatorio")
+	private Integer category_id;
+
+	public String getGtin() {
+		return gtin;
+	}
+
+	public void setGtin(String gtin) {
+		this.gtin = gtin;
+	}
+
+	public String getProduct() {
+		return product;
+	}
+
+	public void setProduct(String product) {
+		this.product = product;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Float getPrice() {
+		return price;
+	}
+
+	public void setPrice(Float price) {
+		this.price = price;
+	}
+
+	public Integer getStock() {
+		return stock;
+	}
+
+	public void setStock(Integer stock) {
+		this.stock = stock;
+	}
+
+	public Integer getCategory_id() {
+		return category_id;
+	}
+
+	public void setCategory_id(Integer category_id) {
+		this.category_id = category_id;
+	}
+}

--- a/src/main/java/com/product/api/dto/in/DtoProductIn.java
+++ b/src/main/java/com/product/api/dto/in/DtoProductIn.java
@@ -6,78 +6,159 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
+/**
+ * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a la entrada de datos de productos
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 public class DtoProductIn {
 
+	/**
+     * Número Global de Artículo Comercial
+	 * No puede tener un valor nulo.
+     */
 	@JsonProperty("gtin")
 	@Pattern(regexp = "^\\+?\\d{13}$", message = "El gtin tiene un formato inválido")
 	@NotNull(message="El gtin es obligatorio")
 	private String gtin;
 	
+	/**
+     * Nombre del producto
+	 * No puede tener un valor nulo.
+     */
 	@JsonProperty("product")
 	@NotNull(message="El product es obligatorio")
 	private String product;
 	
+	/**
+     * Descripción del producto
+	 * No puede tener un valor nulo.
+     */
 	@JsonProperty("description")
 	@NotNull(message="El description es obligatorio")
 	private String description;
 	
+	/**
+     * Precio del producto
+	 * No puede tener un valor nulo.
+	 * El valor no puede ser negativo
+     */
 	@JsonProperty("price")
 	@Min(value = 0)
 	@NotNull(message="El price es obligatorio")
 	private Float price;
 	
+	/**
+     * Cantidad restante de producto
+	 * No puede tener un valor nulo.
+     */
 	@JsonProperty("stock")
 	@NotNull(message="El stock es obligatorio")
 	private Integer stock;
 
+	/**
+     * Identificador de la categoría
+	 * No puede tener un valor nulo.
+     */
 	@JsonProperty("category_id")
 	@NotNull(message="El category_id es obligatorio")
 	private Integer category_id;
 
+	/**
+	 * Regresa el Número Global de Artículo Comercial
+	 * @return El Número Global de Artículo Comercial
+	 */
 	public String getGtin() {
 		return gtin;
 	}
 
+	/**
+	 * Actualiza el Número Global de Artículo Comercial
+	 * @param gtin Número Global de Artículo Comercial
+	 */
 	public void setGtin(String gtin) {
 		this.gtin = gtin;
 	}
 
+	/**
+	 * Regresa el nombre del producto
+	 * @return El nombre del producto
+	 */
 	public String getProduct() {
 		return product;
 	}
 
+	/**
+	 * Actualiza el nombre del producto
+	 * @param product nombre del producto
+	 */
 	public void setProduct(String product) {
 		this.product = product;
 	}
 
+	/**
+	 * Regresa la descripción del producto
+	 * @return La descripción del producto
+	 */
 	public String getDescription() {
 		return description;
 	}
 
+	/**
+	 * Actualiza la descripción del producto
+	 * @param description descripción del producto
+	 */
 	public void setDescription(String description) {
 		this.description = description;
 	}
 
+	/**
+	 * Regresa el precio del producto
+	 * @return El precio del producto
+	 */
 	public Float getPrice() {
 		return price;
 	}
 
+	/**
+	 * Actualiza el precio de producto
+	 * @param price precio de producto
+	 */
 	public void setPrice(Float price) {
 		this.price = price;
 	}
 
+	/**
+	 * Regresa la cantidad restante de producto
+	 * @return La cantidad restante de producto
+	 */
 	public Integer getStock() {
 		return stock;
 	}
 
+	/**
+	 * Actualiza la cantidad restante de producto
+	 * @param stock cantidad restante de producto
+	 */
 	public void setStock(Integer stock) {
 		this.stock = stock;
 	}
 
+	/**
+	 * Regresa el identificador de la categoría
+	 * @return El identificador de la categoría
+	 */
 	public Integer getCategory_id() {
 		return category_id;
 	}
 
+	/**
+	 * Actualiza el identificador de la categoría
+	 * @param category_id identificador de la categoría
+	 */
 	public void setCategory_id(Integer category_id) {
 		this.category_id = category_id;
 	}

--- a/src/main/java/com/product/api/dto/out/DtoProductListOut.java
+++ b/src/main/java/com/product/api/dto/out/DtoProductListOut.java
@@ -1,0 +1,71 @@
+package com.product.api.dto.out;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DtoProductListOut {
+	
+	@JsonProperty("product_id")
+	private Integer product_id;
+	
+	@JsonProperty("gtin")
+	private String gtin;
+
+	@JsonProperty("product")
+	private String product;
+
+	@JsonProperty("price")
+	private Float price;
+
+	@JsonProperty("status")
+	private Integer status;
+
+	public DtoProductListOut(Integer product_id, String gtin, String product, Float price, Integer status) {
+		super();
+		this.product_id = product_id;
+		this.gtin = gtin;
+		this.product = product;
+		this.price = price;
+		this.status = status;
+	}
+
+	public Integer getProduct_id() {
+		return product_id;
+	}
+
+	public void setProduct_id(Integer product_id) {
+		this.product_id = product_id;
+	}
+
+	public String getGtin() {
+		return gtin;
+	}
+
+	public void setGtin(String gtin) {
+		this.gtin = gtin;
+	}
+
+	public String getProduct() {
+		return product;
+	}
+
+	public void setProduct(String product) {
+		this.product = product;
+	}
+
+	public Float getPrice() {
+		return price;
+	}
+
+	public void setPrice(Float price) {
+		this.price = price;
+	}
+
+	public Integer getStatus() {
+		return status;
+	}
+
+	public void setStatus(Integer status) {
+		this.status = status;
+	}
+
+}

--- a/src/main/java/com/product/api/dto/out/DtoProductListOut.java
+++ b/src/main/java/com/product/api/dto/out/DtoProductListOut.java
@@ -2,23 +2,54 @@ package com.product.api.dto.out;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a la salida de datos para lista de productos
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 public class DtoProductListOut {
 	
+	/**
+     * Identificador del producto
+     */
 	@JsonProperty("product_id")
 	private Integer product_id;
 	
+	/**
+     * Número Global de Artículo Comercial
+     */
 	@JsonProperty("gtin")
 	private String gtin;
 
+	/**
+     * Nombre del producto
+     */
 	@JsonProperty("product")
 	private String product;
 
+	/**
+     * Precio del producto
+     */
 	@JsonProperty("price")
 	private Float price;
 
+	/**
+     * Estado del producto (desactivado 0 / activo 1)
+     */
 	@JsonProperty("status")
 	private Integer status;
 
+	/**
+	 * Constructor de la clase
+	 * @param product_id identificador del producto
+	 * @param gtin Número Global de Artículo Comercial
+	 * @param product nombre del producto
+	 * @param price precio del producto
+	 * @param status estado del producto
+	 */
 	public DtoProductListOut(Integer product_id, String gtin, String product, Float price, Integer status) {
 		super();
 		this.product_id = product_id;
@@ -28,42 +59,82 @@ public class DtoProductListOut {
 		this.status = status;
 	}
 
+	/**
+	 * Regresa el identificador del producto
+	 * @return El identificador del producto
+	 */
 	public Integer getProduct_id() {
 		return product_id;
 	}
 
+	/**
+	 * Actualiza el identificador del producto
+	 * @param product_id identificador del producto
+	 */
 	public void setProduct_id(Integer product_id) {
 		this.product_id = product_id;
 	}
 
+	/**
+	 * Regresa el Número Global de Artículo Comercial
+	 * @return El Número Global de Artículo Comercial
+	 */
 	public String getGtin() {
 		return gtin;
 	}
 
+	/**
+	 * Actualiza el Número Global de Artículo Comercial
+	 * @param gtin Número Global de Artículo Comercial
+	 */
 	public void setGtin(String gtin) {
 		this.gtin = gtin;
 	}
 
+	/**
+	 * Regresa el nombre del producto
+	 * @return El nombre del producto
+	 */
 	public String getProduct() {
 		return product;
 	}
 
+	/**
+	 * Actualiza el nombre del producto
+	 * @param product nombre del producto
+	 */
 	public void setProduct(String product) {
 		this.product = product;
 	}
 
+	/**
+	 * Regresa el precio del producto
+	 * @return El precio del producto
+	 */
 	public Float getPrice() {
 		return price;
 	}
 
+	/**
+	 * Actualiza el precio de producto
+	 * @param price precio de producto
+	 */
 	public void setPrice(Float price) {
 		this.price = price;
 	}
 
+	/**
+	 * Regresa el estado de la categoría
+	 * @return El estado de la categoría
+	 */
 	public Integer getStatus() {
 		return status;
 	}
 
+	/**
+	 * Actualiza el estado de la categoría
+	 * @param status estado de la categoría
+	 */
 	public void setStatus(Integer status) {
 		this.status = status;
 	}

--- a/src/main/java/com/product/api/dto/out/DtoProductOut.java
+++ b/src/main/java/com/product/api/dto/out/DtoProductOut.java
@@ -1,0 +1,5 @@
+package com.product.api.dto.out;
+
+public class DtoProductOut {
+	
+}

--- a/src/main/java/com/product/api/dto/out/DtoProductOut.java
+++ b/src/main/java/com/product/api/dto/out/DtoProductOut.java
@@ -1,5 +1,10 @@
 package com.product.api.dto.out;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a la salida de datos de productos
  * 
@@ -8,6 +13,83 @@ package com.product.api.dto.out;
  * @version 0.7.0
  * @beta
  */
+@Entity
+@Table(name = "product")
 public class DtoProductOut {
 	
+	@Id
+	private Integer product_id;
+	private String gtin;
+	private String product;
+	private String description;
+	private Float price;
+	private Integer stock;
+	private String category;
+	
+	@Transient
+	private String image;
+
+	public Integer getProduct_id() {
+		return product_id;
+	}
+
+	public void setProduct_id(Integer product_id) {
+		this.product_id = product_id;
+	}
+
+	public String getGtin() {
+		return gtin;
+	}
+
+	public void setGtin(String gtin) {
+		this.gtin = gtin;
+	}
+
+	public String getProduct() {
+		return product;
+	}
+
+	public void setProduct(String product) {
+		this.product = product;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Float getPrice() {
+		return price;
+	}
+
+	public void setPrice(Float price) {
+		this.price = price;
+	}
+
+	public Integer getStock() {
+		return stock;
+	}
+
+	public void setStock(Integer stock) {
+		this.stock = stock;
+	}
+
+	public String getCategory() {
+		return category;
+	}
+
+	public void setCategory(String category) {
+		this.category = category;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
 }

--- a/src/main/java/com/product/api/dto/out/DtoProductOut.java
+++ b/src/main/java/com/product/api/dto/out/DtoProductOut.java
@@ -1,5 +1,13 @@
 package com.product.api.dto.out;
 
+/**
+ * Clase encargada de ser un Objeto de Transferencia de Datos (DTO) para lo relacionado a la salida de datos de productos
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 public class DtoProductOut {
 	
 }

--- a/src/main/java/com/product/api/entity/Category.java
+++ b/src/main/java/com/product/api/entity/Category.java
@@ -21,14 +21,13 @@ import jakarta.validation.constraints.NotNull;
 @Table(name = "category")
 public class Category {
 
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     /**
      * Identificador de la categoría
      */
     @JsonProperty("category_id")
-    @Column(name = "category_id")
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
     private Integer category_id;
 
     /**
@@ -47,7 +46,6 @@ public class Category {
     
     /**
      * Estado de la categoría
-     * @hidden
      */
     @JsonProperty("status")
     @Column(name = "status")
@@ -84,8 +82,8 @@ public class Category {
     }
 
     /**
-     * Regresa el Estado de la categoría
-     * @return El Estado de la categoría
+     * Regresa el estado de la categoría
+     * @return El estado de la categoría
      */
     public Integer getStatus() {
         return status;
@@ -93,7 +91,7 @@ public class Category {
 
     /**
      * Actualiza el identificador de la categoría
-     * @param category_id Identificador de la categoría
+     * @param category_id identificador de la categoría
      */
     public void setCategory_id(Integer category_id) {
         this.category_id = category_id;
@@ -101,7 +99,7 @@ public class Category {
 
     /**
      * Actualiza el nombre de la categoría
-     * @param category Nombre de la categoría
+     * @param category nombre de la categoría
      */
     public void setCategory(String category) {
         this.category = category;
@@ -109,7 +107,7 @@ public class Category {
 
     /**
      * Actualiza la etiqueta de la categoría
-     * @param tag Etiqueta de la categoría
+     * @param tag etiqueta de la categoría
      */
     public void setTag(String tag) {
         this.tag = tag;

--- a/src/main/java/com/product/api/entity/Product.java
+++ b/src/main/java/com/product/api/entity/Product.java
@@ -1,0 +1,104 @@
+package com.product.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "product")
+public class Product {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "product_id")
+	private Integer product_id;
+	
+	@Column(name = "gtin")
+	private String gtin;
+
+	@Column(name = "product")
+	private String product;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "price")
+	private Float price;
+
+	@Column(name = "stock")
+	private Integer stock;
+
+	@Column(name = "category_id")
+	private Integer category_id;
+
+	@Column(name = "status")
+	private Integer status;
+
+	public Integer getProduct_id() {
+		return product_id;
+	}
+
+	public void setProduct_id(Integer product_id) {
+		this.product_id = product_id;
+	}
+
+	public String getGtin() {
+		return gtin;
+	}
+
+	public void setGtin(String gtin) {
+		this.gtin = gtin;
+	}
+
+	public String getProduct() {
+		return product;
+	}
+
+	public void setProduct(String product) {
+		this.product = product;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Float getPrice() {
+		return price;
+	}
+
+	public void setPrice(Float price) {
+		this.price = price;
+	}
+
+	public Integer getStock() {
+		return stock;
+	}
+
+	public void setStock(Integer stock) {
+		this.stock = stock;
+	}
+
+	public Integer getCategory_id() {
+		return category_id;
+	}
+
+	public void setCategory_id(Integer category_id) {
+		this.category_id = category_id;
+	}
+
+	public Integer getStatus() {
+		return status;
+	}
+
+	public void setStatus(Integer status) {
+		this.status = status;
+	}
+
+}

--- a/src/main/java/com/product/api/entity/Product.java
+++ b/src/main/java/com/product/api/entity/Product.java
@@ -7,96 +7,191 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+/**
+ * Clase que representa un producto como entidad
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 @Entity
 @Table(name = "product")
 public class Product {
 	
+	/**
+     * Identificador del producto
+     */
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "product_id")
 	private Integer product_id;
 	
+	/**
+     * Número Global de Artículo Comercial
+     */
 	@Column(name = "gtin")
 	private String gtin;
 
+	/**
+     * Nombre del producto
+     */
 	@Column(name = "product")
 	private String product;
 
+	/**
+     * Descripción del producto
+     */
 	@Column(name = "description")
 	private String description;
 
+	/**
+     * Precio del producto
+     */
 	@Column(name = "price")
 	private Float price;
 
+	/**
+     * Cantidad restante de producto
+     */
 	@Column(name = "stock")
 	private Integer stock;
 
+	/**
+     * Identificador de la categoría
+     */
 	@Column(name = "category_id")
 	private Integer category_id;
 
+	/**
+     * Estado del producto (desactivado 0 / activo 1)
+     */
 	@Column(name = "status")
 	private Integer status;
 
+	/**
+	 * Regresa el identificador del producto
+	 * @return El identificador del producto
+	 */
 	public Integer getProduct_id() {
 		return product_id;
 	}
 
+	/**
+	 * Actualiza el identificador del producto
+	 * @param product_id identificador del producto
+	 */
 	public void setProduct_id(Integer product_id) {
 		this.product_id = product_id;
 	}
 
+	/**
+	 * Regresa el Número Global de Artículo Comercial
+	 * @return El Número Global de Artículo Comercial
+	 */
 	public String getGtin() {
 		return gtin;
 	}
 
+	/**
+	 * Actualiza el Número Global de Artículo Comercial
+	 * @param gtin Número Global de Artículo Comercial
+	 */
 	public void setGtin(String gtin) {
 		this.gtin = gtin;
 	}
 
+	/**
+	 * Regresa el nombre del producto
+	 * @return El nombre del producto
+	 */
 	public String getProduct() {
 		return product;
 	}
 
+	/**
+	 * Actualiza el nombre del producto
+	 * @param product nombre del producto
+	 */
 	public void setProduct(String product) {
 		this.product = product;
 	}
 
+	/**
+	 * Regresa la descripción del producto
+	 * @return La descripción del producto
+	 */
 	public String getDescription() {
 		return description;
 	}
 
+	/**
+	 * Actualiza la descripción del producto
+	 * @param description descripción del producto
+	 */
 	public void setDescription(String description) {
 		this.description = description;
 	}
 
+	/**
+	 * Regresa el precio del producto
+	 * @return El precio del producto
+	 */
 	public Float getPrice() {
 		return price;
 	}
 
+	/**
+	 * Actualiza el precio de producto
+	 * @param price precio de producto
+	 */
 	public void setPrice(Float price) {
 		this.price = price;
 	}
 
+	/**
+	 * Regresa la cantidad restante de producto
+	 * @return La cantidad restante de producto
+	 */
 	public Integer getStock() {
 		return stock;
 	}
 
+	/**
+	 * Actualiza la cantidad restante de producto
+	 * @param stock cantidad restante de producto
+	 */
 	public void setStock(Integer stock) {
 		this.stock = stock;
 	}
 
+	/**
+	 * Regresa el identificador de la categoría
+	 * @return El identificador de la categoría
+	 */
 	public Integer getCategory_id() {
 		return category_id;
 	}
 
+	/**
+	 * Actualiza el identificador de la categoría
+	 * @param category_id identificador de la categoría
+	 */
 	public void setCategory_id(Integer category_id) {
 		this.category_id = category_id;
 	}
 
+	/**
+	 * Regresa el estado de la categoría
+	 * @return El estado de la categoría
+	 */
 	public Integer getStatus() {
 		return status;
 	}
 
+	/**
+	 * Actualiza el estado de la categoría
+	 * @param status estado de la categoría
+	 */
 	public void setStatus(Integer status) {
 		this.status = status;
 	}

--- a/src/main/java/com/product/api/entity/ProductImage.java
+++ b/src/main/java/com/product/api/entity/ProductImage.java
@@ -1,0 +1,110 @@
+package com.product.api.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Clase que representa una imagen de un producto como entidad
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
+@Entity
+@Table(name = "product_image")
+public class ProductImage {
+    
+    /**
+     * Identificador de la imagen de un producto
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_image_id")
+    private Integer productImageId;
+
+    /**
+     * Identificador del producto
+     */
+    @Column(name = "product_id")
+    private Integer productId;
+
+    /**
+     * Imagen de producto
+     */
+    @Column(name = "image")
+    private String image;
+
+    /**
+     * Estado de la imagen
+     */
+    @Column(name = "status")
+    private Integer status;
+    
+    /**
+     * Regresa un identificador de la imagen del producto
+     * @return un identificador de la imagen del producto
+     */
+    public Integer getProductImage_id() {
+        return productImageId;
+    }
+
+    /**
+     * Regresa el identificador del producto
+     * @return el identificador del producto
+     */
+    public Integer getProduct_id() {
+        return productId;
+    }
+
+    /**
+     * Regresa la imagen de producto
+     * @return la imagen de producto
+     */
+    public String getImage() {
+        return image;
+    }
+
+    /**
+     * Regresa el estado de la imagen de producto
+     * @return el estado de la imagen de producto
+     */
+    public Integer getStatus() {
+        return status;
+    }
+
+    /**
+     * Actualiza el identificador de la imagen de producto
+     * @param productImageId identificador de la imagen de producto
+     */
+    public void setProductImage_id(Integer productImageId) {
+        this.productImageId = productImageId;
+    }
+
+    /**
+     * Actualiza el identificador del producto
+     * @param productImageId identificador del producto
+     */
+    public void setProduct_id(Integer productId) {
+        this.productId = productId;
+    }
+
+    /**
+     * Actualiza la imagen de producto
+     * @param productImageId imagen de producto
+     */
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+     * Actualiza el estado de la imagen de producto
+     * @param productImageId estado de la imagen de producto
+     */
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/product/api/repository/RepoCategory.java
+++ b/src/main/java/com/product/api/repository/RepoCategory.java
@@ -21,20 +21,6 @@ import jakarta.transaction.Transactional;
  */
 @Repository
 public interface RepoCategory extends JpaRepository<Category, Integer> {
-    
-    /**
-     * Obtiene todas las categorías
-     * @deprecated
-     */
-    @Query(value = "SELECT * FROM category ORDER BY category", nativeQuery = true)
-    List<Category> getCategories();
-
-    /**
-     * Obtiene todas las categorías activas
-     * @deprecated
-     */
-    @Query(value = "SELECT * FROM category WHERE status=1 ORDER BY category", nativeQuery = true)
-    List<Category> getActiveCategories();
 
     /**
      * Obtiene todas las categorías

--- a/src/main/java/com/product/api/repository/RepoProduct.java
+++ b/src/main/java/com/product/api/repository/RepoProduct.java
@@ -1,0 +1,11 @@
+package com.product.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.product.api.entity.Product;
+
+@Repository
+public interface RepoProduct extends JpaRepository<Product, Integer> {
+
+}

--- a/src/main/java/com/product/api/repository/RepoProduct.java
+++ b/src/main/java/com/product/api/repository/RepoProduct.java
@@ -1,8 +1,10 @@
 package com.product.api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.product.api.dto.out.DtoProductOut;
 import com.product.api.entity.Product;
 
 /**
@@ -15,4 +17,14 @@ import com.product.api.entity.Product;
 @Repository
 public interface RepoProduct extends JpaRepository<Product, Integer> {
 
+	/**
+	 * Obtiene un producto con su categoría mediante un INNER JOIN
+	 * @param product_id identificador del producto
+	 * @return Un objeto de transferencia con los datos del producto y su categoría
+	 */
+	@Query(value = "SELECT p.*, c.category "
+			+ "FROM product p "
+			+ "INNER JOIN category c ON c.category_id = p.category_id "
+			+ "WHERE p.product_id = :product_id", nativeQuery = true)
+	DtoProductOut getProduct(Integer product_id);
 }

--- a/src/main/java/com/product/api/repository/RepoProduct.java
+++ b/src/main/java/com/product/api/repository/RepoProduct.java
@@ -5,6 +5,13 @@ import org.springframework.stereotype.Repository;
 
 import com.product.api.entity.Product;
 
+/**
+ * Interfaz de repositorio para productos en la DB
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 @Repository
 public interface RepoProduct extends JpaRepository<Product, Integer> {
 

--- a/src/main/java/com/product/api/repository/RepoProductImage.java
+++ b/src/main/java/com/product/api/repository/RepoProductImage.java
@@ -23,7 +23,7 @@ public interface RepoProductImage extends JpaRepository<ProductImage, Integer> {
      * @param id identificador del producto
      * @return Todas las imagenes de un producto con id dado, a manera de lista
      */
-    List<ProductImage> findByProductIdOrderByProductAsc(Integer id);
+    List<ProductImage> findByProductIdOrderByProductImageIdAsc(Integer id);
 
 
     /**

--- a/src/main/java/com/product/api/repository/RepoProductImage.java
+++ b/src/main/java/com/product/api/repository/RepoProductImage.java
@@ -1,0 +1,18 @@
+package com.product.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.product.api.entity.ProductImage;
+
+/**
+ * Interfaz de repositorio para las imagenes de los productos en la DB
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
+@Repository
+public interface RepoProductImage extends JpaRepository<ProductImage, Integer> {
+    
+}

--- a/src/main/java/com/product/api/repository/RepoProductImage.java
+++ b/src/main/java/com/product/api/repository/RepoProductImage.java
@@ -1,5 +1,7 @@
 package com.product.api.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +16,12 @@ import com.product.api.entity.ProductImage;
  */
 @Repository
 public interface RepoProductImage extends JpaRepository<ProductImage, Integer> {
-    
+
+    /**
+     * Obtiene todas las imagenes de un producto con id dado
+     * Ordenadas por nombre de manera ascendente
+     * @param id identificador del producto
+     * @return Todas las imagenes de un producto con id dado, a manera de lista
+     */
+    List<ProductImage> findByProductIdOrderByProductAsc(Integer id);
 }

--- a/src/main/java/com/product/api/repository/RepoProductImage.java
+++ b/src/main/java/com/product/api/repository/RepoProductImage.java
@@ -24,4 +24,12 @@ public interface RepoProductImage extends JpaRepository<ProductImage, Integer> {
      * @return Todas las imagenes de un producto con id dado, a manera de lista
      */
     List<ProductImage> findByProductIdOrderByProductAsc(Integer id);
+
+
+    /**
+     * Obtiene la imagen de un producto con id dado
+     * @param product_id identificador del producto
+     * @return La imagen del producto con id dado
+     */
+    ProductImage findByProductId(Integer product_id);
 }

--- a/src/main/java/com/product/api/service/SvcCategory.java
+++ b/src/main/java/com/product/api/service/SvcCategory.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 
 import com.product.api.entity.Category;
+import com.product.exception.ApiException;
+import com.product.exception.DBAccessException;
 import com.product.api.dto.in.DtoCategoryIn;
 import com.commons.dto.ApiResponse;
 
@@ -20,31 +22,56 @@ public interface SvcCategory {
     
     /**
      * Obtiene todas las categorías
+     * @return Una lista con todas categorías
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      */
     public List<Category> findAll();
     
     /**
      * Obtiene todas las categorías activas
+     * @return Una lista con las categorías activas
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      */
     public List<Category> findActive();
     
     /**
      * Crea una categoría
+     * @param in objeto de transferencia de una categoría
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El nombre de la categoría
+     *                      La etiqueta de la categoría
      */
     public ApiResponse create(DtoCategoryIn in);
     
     /**
      * Actualiza una categoría
+     * @param in objeto de transferencia de una categoría
+     * @param id identificador de la categoría buscada
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador de la categoría
+     *                      Campo ya registrado en el nombre de la categoría
+     *                      Campo ya registrado en la etiqueta de la categoría
      */
     public ApiResponse update(DtoCategoryIn in, Integer id);
     
     /**
      * Habilita una categoría
+     * @param id identificador de la categoría buscada
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador de la categoría
      */
     public ApiResponse enable(Integer id);
     
     /**
      * Deshabilita una categoría
+     * @param id identificador de la categoría buscada
+     * @return Una respuesta que indíca el éxito o error en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador de la categoría
      */
     public ApiResponse disable(Integer id);
 

--- a/src/main/java/com/product/api/service/SvcCategory.java
+++ b/src/main/java/com/product/api/service/SvcCategory.java
@@ -9,7 +9,7 @@ import com.product.api.dto.in.DtoCategoryIn;
 import com.commons.dto.ApiResponse;
 
 /**
- * Interfaz dedicvada a clases de servicio para acceso controlado.
+ * Interfaz dedicada a clases de servicio para acceso controlado de categorías.
  * 
  * @author Isaac Robledo R
  * @author Alejandro Sánchez E

--- a/src/main/java/com/product/api/service/SvcCategory.java
+++ b/src/main/java/com/product/api/service/SvcCategory.java
@@ -20,18 +20,6 @@ public interface SvcCategory {
     
     /**
      * Obtiene todas las categorías
-     * @deprecated
-     */
-    public ResponseEntity<List<Category>> getCategories();
-
-    /**
-     * Obtiene todas las categorías activas
-     * @deprecated 
-     */
-    public ResponseEntity<List<Category>> getActiveCategories();
-    
-    /**
-     * Obtiene todas las categorías
      */
     public List<Category> findAll();
     

--- a/src/main/java/com/product/api/service/SvcCategory.java
+++ b/src/main/java/com/product/api/service/SvcCategory.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 
 import com.product.api.entity.Category;
-import com.product.api.dto.DtoCategoryIn;
+import com.product.api.dto.in.DtoCategoryIn;
 import com.commons.dto.ApiResponse;
 
 /**

--- a/src/main/java/com/product/api/service/SvcCategoryImp.java
+++ b/src/main/java/com/product/api/service/SvcCategoryImp.java
@@ -33,49 +33,6 @@ public class SvcCategoryImp implements SvcCategory {
     private RepoCategory repo;
 
     /**
-     * Constructor de cadenas mutables.
-     * Ayuda con la eficiencia al escribir varios caracteres
-     */
-    private StringBuilder sb;
-
-    /**
-     * Constructor del gestor de categorías
-     */
-    public SvcCategoryImp() {
-        this.sb = new StringBuilder();
-    }
-
-    /**
-     * Regresa una respuesta con la lista con todas categorías
-     * @return Una respuesta con la lista con todas categorías
-     * @estado 200 - Operación realizada con éxito
-     * @deprecated
-     */
-    @Override
-    public ResponseEntity<List<Category>> getCategories() {
-        try {
-            return new ResponseEntity<List<Category>>(repo.getCategories(), HttpStatus.OK);
-        } catch (DataAccessException e) {
-            throw new DBAccessException(e);
-        }
-    }
-    
-    /**
-     * Regresa una respuesta con la lista con las categorías activas
-     * @return Una respuesta con la lista con las categorías activas
-     * @estado 200 - Operación realizada con éxito
-     * @deprecated
-     */
-    @Override
-    public ResponseEntity<List<Category>> getActiveCategories() {
-        try {
-            return new ResponseEntity<List<Category>>(repo.getActiveCategories(), HttpStatus.OK);
-        } catch (DataAccessException e) {
-            throw new DBAccessException(e);
-        }
-    }
-
-    /**
      * Obtiene todas las categorías
      * @return Una lista con todas categorías
      * @estado 200 - Operación realizada con éxito
@@ -179,8 +136,7 @@ public class SvcCategoryImp implements SvcCategory {
      * @throws ApiException si la categoría no existe
      */
     private void validateCategoryId(Integer id) {
-        if (repo.findById(id).isEmpty()) {
+        if (repo.findById(id).isEmpty())
             throw new ApiException(HttpStatus.NOT_FOUND, "El id de la categoría no existe");
-        }
     }
 }

--- a/src/main/java/com/product/api/service/SvcCategoryImp.java
+++ b/src/main/java/com/product/api/service/SvcCategoryImp.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service;
  * 
  * @author Isaac Robledo R
  * @author Alejandro Sánchez E
- * @version 0.5.0
+ * @version 0.7.0
  * @beta
  */
 @Service
@@ -62,6 +62,7 @@ public class SvcCategoryImp implements SvcCategory {
     
     /**
      * Crea una categoría
+     * @param in objeto de transferencia de una categoría
      * @return Una respuesta que indíca el éxito en la operación
      * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
@@ -83,6 +84,8 @@ public class SvcCategoryImp implements SvcCategory {
     
     /**
      * Actualiza una categoría
+     * @param in objeto de transferencia de una categoría
+     * @param id identificador de la categoría buscada
      * @return Una respuesta que indíca el éxito en la operación
      * @throws ApiException Al encontrar un error en el contenido de:
      *                      El identificador de la categoría
@@ -101,6 +104,7 @@ public class SvcCategoryImp implements SvcCategory {
     
     /**
      * Habilita una categoría
+     * @param id identificador de la categoría buscada
      * @return Una respuesta que indíca el éxito en la operación
      * @throws ApiException Al encontrar un error en el contenido de:
      *                      El identificador de la categoría
@@ -117,6 +121,7 @@ public class SvcCategoryImp implements SvcCategory {
     
     /**
      * Deshabilita una categoría
+     * @param id identificador de la categoría buscada
      * @return Una respuesta que indíca el éxito o error en la operación
      * @throws ApiException Al encontrar un error en el contenido de:
      *                      El identificador de la categoría
@@ -130,7 +135,7 @@ public class SvcCategoryImp implements SvcCategory {
             throw new DBAccessException(e);
         }
     }
-
+    
     /**
      * Valida que el Identificador de la categoría exista
      * @param id identificador de la categoría a validar

--- a/src/main/java/com/product/api/service/SvcCategoryImp.java
+++ b/src/main/java/com/product/api/service/SvcCategoryImp.java
@@ -75,9 +75,9 @@ public class SvcCategoryImp implements SvcCategory {
             return new ApiResponse("La categoría ha sido registrada");
         } catch (DataAccessException e) {
             if (e.getLocalizedMessage().contains("ux_category"))
-            throw new ApiException(HttpStatus.CONFLICT, "El nombre de la categoría ya está registrado");
+                throw new ApiException(HttpStatus.CONFLICT, "El nombre de la categoría ya está registrado");
             if (e.getLocalizedMessage().contains("ux_tag"))
-            throw new ApiException(HttpStatus.CONFLICT, "El tag de la categoría ya está registrado");
+                throw new ApiException(HttpStatus.CONFLICT, "El tag de la categoría ya está registrado");
             throw new DBAccessException(e);
         }
     }

--- a/src/main/java/com/product/api/service/SvcCategoryImp.java
+++ b/src/main/java/com/product/api/service/SvcCategoryImp.java
@@ -1,7 +1,7 @@
 package com.product.api.service;
 
 import com.commons.dto.ApiResponse;
-import com.product.api.dto.DtoCategoryIn;
+import com.product.api.dto.in.DtoCategoryIn;
 import com.product.api.entity.Category;
 import com.product.api.repository.RepoCategory;
 import com.product.exception.DBAccessException;

--- a/src/main/java/com/product/api/service/SvcCategoryImp.java
+++ b/src/main/java/com/product/api/service/SvcCategoryImp.java
@@ -35,7 +35,7 @@ public class SvcCategoryImp implements SvcCategory {
     /**
      * Obtiene todas las categorías
      * @return Una lista con todas categorías
-     * @estado 200 - Operación realizada con éxito
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      */
     @Override
     public List<Category> findAll() {
@@ -49,7 +49,7 @@ public class SvcCategoryImp implements SvcCategory {
     /**
      * Obtiene todas las categorías activas
      * @return Una lista con las categorías activas
-     * @estado 200 - Operación realizada con éxito
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      */
     @Override
     public List<Category> findActive() {
@@ -62,10 +62,11 @@ public class SvcCategoryImp implements SvcCategory {
     
     /**
      * Crea una categoría
-     * @return Una respuesta que indíca el éxito o error en la operación
-     * @estado 200 - La categoría ha sido registrada
-     * @estado 409 - Nombre de la categoría repetida
-     * @estado 409 - Etiqueta de la categoría repetida
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El nombre de la categoría
+     *                      La etiqueta de la categoría
      */
     public ApiResponse create(DtoCategoryIn in) {
         try {
@@ -73,20 +74,20 @@ public class SvcCategoryImp implements SvcCategory {
             return new ApiResponse("La categoría ha sido registrada");
         } catch (DataAccessException e) {
             if (e.getLocalizedMessage().contains("ux_category"))
-                throw new ApiException(HttpStatus.CONFLICT, "El nombre de la categoría ya está registrado");
+            throw new ApiException(HttpStatus.CONFLICT, "El nombre de la categoría ya está registrado");
             if (e.getLocalizedMessage().contains("ux_tag"))
-                throw new ApiException(HttpStatus.CONFLICT, "El tag de la categoría ya está registrado");
+            throw new ApiException(HttpStatus.CONFLICT, "El tag de la categoría ya está registrado");
             throw new DBAccessException(e);
         }
     }
     
     /**
      * Actualiza una categoría
-     * @return Una respuesta que indíca el éxito o error en la operación
-     * @estado 200 - La categoría ha sido actualizada
-     * @estado 404 - ID no encontrado
-     * @estado 409 - Nombre de la categoría repetida
-     * @estado 409 - Etiqueta de la categoría repetida
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador de la categoría
+     *                      Campo ya registrado en el nombre de la categoría
+     *                      Campo ya registrado en la etiqueta de la categoría
      */
     public ApiResponse update(DtoCategoryIn in, Integer id) {
         try {
@@ -100,9 +101,9 @@ public class SvcCategoryImp implements SvcCategory {
     
     /**
      * Habilita una categoría
-     * @return Una respuesta que indíca el éxito o error en la operación
-     * @estado 200 - La categoría ha sido activada
-     * @estado 404 - ID no encontrado
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador de la categoría
      */
     public ApiResponse enable(Integer id) {
         try {
@@ -117,8 +118,8 @@ public class SvcCategoryImp implements SvcCategory {
     /**
      * Deshabilita una categoría
      * @return Una respuesta que indíca el éxito o error en la operación
-     * @estado 200 - La categoría ha sido desactivada
-     * @estado 404 - ID no encontrado
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador de la categoría
      */
     public ApiResponse disable(Integer id) {
         try {
@@ -131,9 +132,9 @@ public class SvcCategoryImp implements SvcCategory {
     }
 
     /**
-     * Valida que el ID de la categoría exista
-     * @param id Identificador de la categoría a validar
-     * @throws ApiException si la categoría no existe
+     * Valida que el Identificador de la categoría exista
+     * @param id identificador de la categoría a validar
+     * @throws ApiException Si el identificador de la categoría no está registrado
      */
     private void validateCategoryId(Integer id) {
         if (repo.findById(id).isEmpty())

--- a/src/main/java/com/product/api/service/SvcProduct.java
+++ b/src/main/java/com/product/api/service/SvcProduct.java
@@ -1,0 +1,21 @@
+package com.product.api.service;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import com.commons.dto.ApiResponse;
+import com.product.api.dto.in.DtoProductIn;
+import com.product.api.dto.out.DtoProductListOut;
+import com.product.api.dto.out.DtoProductOut;
+
+public interface SvcProduct {
+
+	public ResponseEntity<List<DtoProductListOut>> getProducts();
+	public ResponseEntity<DtoProductOut> getProduct(Integer id);
+	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in);
+	public ResponseEntity<ApiResponse> updateProduct(Integer id, DtoProductIn in);
+	public ResponseEntity<ApiResponse> enableProduct(Integer id);
+	public ResponseEntity<ApiResponse> disableProduct(Integer id);
+
+}

--- a/src/main/java/com/product/api/service/SvcProduct.java
+++ b/src/main/java/com/product/api/service/SvcProduct.java
@@ -8,14 +8,75 @@ import com.commons.dto.ApiResponse;
 import com.product.api.dto.in.DtoProductIn;
 import com.product.api.dto.out.DtoProductListOut;
 import com.product.api.dto.out.DtoProductOut;
+import com.product.exception.ApiException;
+import com.product.exception.DBAccessException;
 
+/**
+ * Interfaz dedicada a clases de servicio para acceso controlado de productos.
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 public interface SvcProduct {
 
+	/**
+     * Obtiene una respuesta con todos los productos
+     * @return Una respuesta con todos los productos
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     */
 	public ResponseEntity<List<DtoProductListOut>> getProducts();
+
+	/**
+	 * Obtiene una respuesta con los datos de un producto específico dado su identificador
+	 * @param id identificador del producto
+	 * @return Una respuesta con los datos de un producto específico dado su identificador
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+	 * @throws ApiException Al encontrar un error en el contenido de:
+	 * 						El identificador del producto
+	 */
 	public ResponseEntity<DtoProductOut> getProduct(Integer id);
+
+	/**
+     * Crea un producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El GTIN del producto
+     *                      El nombre del producto
+	 * 						El identificador de la categoría asociado al producto
+     */
 	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in);
+
+	/**
+     * Actualiza un producto
+     * @return Una respuesta que indíca el éxito en la operación
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+	 * 						El identificador del producto
+     *                      Campo ya registrado en el GTIN del producto
+     *                      Campo ya registrado en el nombre del producto
+	 * 						El identificador de la categoría asociado al producto
+     */
 	public ResponseEntity<ApiResponse> updateProduct(Integer id, DtoProductIn in);
+
+	/**
+     * Habilita un producto
+     * @return Una respuesta que indíca el éxito en la operación
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador del producto
+     */
 	public ResponseEntity<ApiResponse> enableProduct(Integer id);
+
+	/**
+     * Deshabilita un producto
+     * @return Una respuesta que indíca el éxito en la operación
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador del producto
+     */
 	public ResponseEntity<ApiResponse> disableProduct(Integer id);
 
 }

--- a/src/main/java/com/product/api/service/SvcProduct.java
+++ b/src/main/java/com/product/api/service/SvcProduct.java
@@ -34,35 +34,39 @@ public interface SvcProduct {
 	 * @return Una respuesta con los datos de un producto específico dado su identificador
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
 	 * @throws ApiException Al encontrar un error en el contenido de:
-	 * 						El identificador del producto
+	 *                      El identificador del producto
 	 */
 	public ResponseEntity<DtoProductOut> getProduct(Integer id);
 
 	/**
      * Crea un producto
+     * @param in objeto de transferencia de un producto
      * @return Una respuesta que indíca el éxito en la operación
      * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
      *                      El GTIN del producto
      *                      El nombre del producto
-	 * 						El identificador de la categoría asociado al producto
+	 *                      El identificador de la categoría asociado al producto
      */
-	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in);
+    public ResponseEntity<ApiResponse> createProduct(DtoProductIn in);
 
 	/**
      * Actualiza un producto
+     * @param in objeto de transferencia de una categoría
+     * @param id identificador del producto
      * @return Una respuesta que indíca el éxito en la operación
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
-	 * 						El identificador del producto
+	 * 				        El identificador del producto
      *                      Campo ya registrado en el GTIN del producto
      *                      Campo ya registrado en el nombre del producto
-	 * 						El identificador de la categoría asociado al producto
+	 * 				        El identificador de la categoría asociado al producto
      */
 	public ResponseEntity<ApiResponse> updateProduct(Integer id, DtoProductIn in);
 
 	/**
      * Habilita un producto
+     * @param id identificador del producto
      * @return Una respuesta que indíca el éxito en la operación
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
@@ -72,6 +76,7 @@ public interface SvcProduct {
 
 	/**
      * Deshabilita un producto
+     * @param id identificador del producto
      * @return Una respuesta que indíca el éxito en la operación
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:

--- a/src/main/java/com/product/api/service/SvcProductImage.java
+++ b/src/main/java/com/product/api/service/SvcProductImage.java
@@ -1,7 +1,10 @@
 package com.product.api.service;
 
+import java.util.List;
+
 import com.commons.dto.ApiResponse;
 import com.product.api.dto.in.DtoProductImageIn;
+import com.product.api.entity.ProductImage;
 import com.product.exception.ApiException;
 import com.product.exception.DBAccessException;
 
@@ -14,6 +17,17 @@ import com.product.exception.DBAccessException;
  * @beta
  */
 public interface SvcProductImage {
+    
+    /**
+     * Obtiene la lista de imagenes de un producto dado
+     * @param id identificador del producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      Al codificar las imagenes
+     *                      El identificador del producto
+     */
+    public List<ProductImage> findAll(Integer id);
 
     /**
      * Sube una imagen para un producto
@@ -24,17 +38,6 @@ public interface SvcProductImage {
      *                      Al guardar archivo
      */
     public ApiResponse upload(DtoProductImageIn in);
-
-    /**
-     * Obtiene la lista de imagenes de un producto dado
-     * @param id identificador del producto
-     * @return Una respuesta que indíca el éxito en la operación
-     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
-     * @throws ApiException Al encontrar un error en el contenido de:
-     *                      Al codificar las imagenes
-     *                      El identificador del producto
-     */
-    public ApiResponse findAll(Integer id);
 
     /**
      * Elimina una imagen de un producto

--- a/src/main/java/com/product/api/service/SvcProductImage.java
+++ b/src/main/java/com/product/api/service/SvcProductImage.java
@@ -1,0 +1,51 @@
+package com.product.api.service;
+
+import com.commons.dto.ApiResponse;
+import com.product.api.dto.in.DtoProductImageIn;
+import com.product.exception.ApiException;
+import com.product.exception.DBAccessException;
+
+/**
+ * Interfaz dedicada a clases de servicio para acceso controlado de imagenes de productos.
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
+public interface SvcProductImage {
+
+    /**
+     * Sube una imagen para un producto
+     * @param in objeto de transferenica de una imagen para un producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      Al guardar archivo
+     */
+    public ApiResponse upload(DtoProductImageIn in);
+
+    /**
+     * Obtiene la lista de imagenes de un producto dado
+     * @param id identificador del producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      Al codificar las imagenes
+     *                      El identificador del producto
+     */
+    public ApiResponse findAll(Integer id);
+
+    /**
+     * Elimina una imagen de un producto
+     * @param id identificador del producto
+     * @param product_image_id identificador de la imagen del producto
+     * @return Una respuesta que indica el éxito en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador del producto
+     *                      El identificador de la imagen de producto
+     *                      La ruta de la imagen
+     */
+    public ApiResponse delete(Integer id, Integer product_image_id);
+
+}

--- a/src/main/java/com/product/api/service/SvcProductImageImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImageImp.java
@@ -79,7 +79,9 @@ public class SvcProductImageImp implements SvcProductImage {
 	@Override
 	public ApiResponse upload(DtoProductImageIn in) {
 		try {
-            validateProductId(in.getProduct_id());
+            ProductImage productImage = repo.findByProductId(in.getProduct_id());
+            if(productImage == null)
+                throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
 
 		    // Decodifica la cadena Base64 a bytes
             byte[] imageBytes = Base64.getDecoder().decode(in.getImage());
@@ -96,7 +98,7 @@ public class SvcProductImageImp implements SvcProductImage {
             // Escribir el archivo en el sistema de archivos
             Files.write(imagePath, imageBytes);
 
-            ProductImage productImage = new ProductImage();
+            productImage = new ProductImage();
             productImage.setImage("/" + uploadDir + "/img/customer/" + fileName);
             productImage.setStatus(1); 
 

--- a/src/main/java/com/product/api/service/SvcProductImageImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImageImp.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import com.commons.dto.ApiResponse;
 import com.product.api.dto.in.DtoProductImageIn;
 import com.product.api.entity.ProductImage;
+import com.product.api.repository.RepoProduct;
 import com.product.api.repository.RepoProductImage;
 import com.product.exception.ApiException;
 import com.product.exception.DBAccessException;
@@ -37,12 +39,34 @@ public class SvcProductImageImp implements SvcProductImage {
 	@Autowired
 	RepoProductImage repo;
 
+    @Autowired
+    RepoProduct repoProduct;
+
     /**
      * Ruta del directorio para almacenar imagenes de producto
      */
     @Value("${app.upload.dir}")
     private String uploadDir;
 
+    /**
+     * Obtiene la lista de imagenes de un producto dado
+     * @param id identificador del producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      Al codificar las imagenes
+     *                      El identificador del producto
+     */
+    @Override
+    public List<ProductImage> findAll(Integer id) {
+        try {
+            validateProductId(id);
+
+            return repo.findByProductIdOrderByProductAsc(id);
+        } catch (DataAccessException e) {
+            throw new DBAccessException(e);
+        }
+    }
 
     /**
      * Sube una imagen para un producto
@@ -55,6 +79,8 @@ public class SvcProductImageImp implements SvcProductImage {
 	@Override
 	public ApiResponse upload(DtoProductImageIn in) {
 		try {
+            validateProductId(in.getProduct_id());
+
 		    // Decodifica la cadena Base64 a bytes
             byte[] imageBytes = Base64.getDecoder().decode(in.getImage());
 
@@ -71,7 +97,6 @@ public class SvcProductImageImp implements SvcProductImage {
             Files.write(imagePath, imageBytes);
 
             ProductImage productImage = new ProductImage();
-            productImage.setProductImage_id(in.getProductImage_id());
             productImage.setImage("/" + uploadDir + "/img/customer/" + fileName);
             productImage.setStatus(1); 
 
@@ -92,5 +117,58 @@ public class SvcProductImageImp implements SvcProductImage {
             throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Error al guardar el archivo");
         }
 	}
+
+    /**
+     * Elimina una imagen de un producto
+     * @param id identificador del producto
+     * @param product_image_id identificador de la imagen del producto
+     * @return Una respuesta que indica el éxito en la operación
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador del producto
+     *                      El identificador de la imagen de producto
+     *                      La ruta de la imagen
+     */
+    public ApiResponse delete(Integer id, Integer product_image_id) {
+        try {
+        validateProductImageId(product_image_id);
+        validateProductId(id);
+        validateRelation(id, product_image_id);
+
+        repo.deleteById(product_image_id);
+        return new ApiResponse("La imagen ha sido eliminada");
+        } catch (DataAccessException e) {
+            throw new DBAccessException(e);
+        }
+    }
+
+    /**
+     * Valida que el Identificador de la imagen de producto exista
+     * @param id identificador de la imagen de producto a validar
+     * @throws ApiException Si el identificador de la imagen de producto no está registrado
+     */
+    private void validateProductImageId(Integer id) {
+        if (repo.findById(id).isEmpty())
+            throw new ApiException(HttpStatus.NOT_FOUND, "El id de la imagen de producto no existe");
+    }
+
+    /**
+     * Valida que el Identificador del producto exista
+     * @param id identificador del producto a validar
+     * @throws ApiException Si el identificador del producto no está registrado
+     */
+    private void validateProductId(Integer id) {
+        if (repoProduct.findById(id).isEmpty())
+            throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
+    }
+
+    /**
+     * Valida que el Identificador del producto exista
+     * @param id identificador de la imagen de producto a validar
+     * @throws ApiException Si el identificador del producto no está registrado
+     */
+    private void validateRelation(Integer id, Integer product_image_id) {
+        if (repo.findById(product_image_id).get().getProduct_id() != id)
+            throw new ApiException(HttpStatus.BAD_REQUEST, "La imagen no corresponde al producto buscado");
+    }
 }
 

--- a/src/main/java/com/product/api/service/SvcProductImageImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImageImp.java
@@ -62,7 +62,7 @@ public class SvcProductImageImp implements SvcProductImage {
         try {
             validateProductId(id);
 
-            return repo.findByProductIdOrderByProductAsc(id);
+            return repo.findByProductIdOrderByProductImageIdAsc(id);
         } catch (DataAccessException e) {
             throw new DBAccessException(e);
         }

--- a/src/main/java/com/product/api/service/SvcProductImageImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImageImp.java
@@ -80,8 +80,11 @@ public class SvcProductImageImp implements SvcProductImage {
 	public ApiResponse upload(DtoProductImageIn in) {
 		try {
             ProductImage productImage = repo.findByProductId(in.getProduct_id());
-            if(productImage == null)
-                throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
+             if (in.getImage().startsWith("data:image")) {
+                int commaIndex = in.getImage().indexOf(",");
+                if (commaIndex != -1)
+                    in.setImage(in.getImage().substring(commaIndex + 1));
+            }
 
 		    // Decodifica la cadena Base64 a bytes
             byte[] imageBytes = Base64.getDecoder().decode(in.getImage());
@@ -99,6 +102,7 @@ public class SvcProductImageImp implements SvcProductImage {
             Files.write(imagePath, imageBytes);
 
             productImage = new ProductImage();
+                productImage.setProduct_id(in.getProduct_id());
             productImage.setImage("/" + uploadDir + "/img/customer/" + fileName);
             productImage.setStatus(1); 
 

--- a/src/main/java/com/product/api/service/SvcProductImageImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImageImp.java
@@ -1,0 +1,96 @@
+package com.product.api.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.commons.dto.ApiResponse;
+import com.product.api.dto.in.DtoProductImageIn;
+import com.product.api.entity.ProductImage;
+import com.product.api.repository.RepoProductImage;
+import com.product.exception.ApiException;
+import com.product.exception.DBAccessException;
+
+/**
+ * Clase de servicio para imagenes de productos.
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
+@Service
+public class SvcProductImageImp implements SvcProductImage {
+
+    /**
+	 * Repositorio para imagenes de producto
+	 */
+	@Autowired
+	RepoProductImage repo;
+
+    /**
+     * Ruta del directorio para almacenar imagenes de producto
+     */
+    @Value("${app.upload.dir}")
+    private String uploadDir;
+
+
+    /**
+     * Sube una imagen para un producto
+     * @param in objeto de transferenica de una imagen para un producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      Al guardar archivo
+     */
+	@Override
+	public ApiResponse upload(DtoProductImageIn in) {
+		try {
+		    // Decodifica la cadena Base64 a bytes
+            byte[] imageBytes = Base64.getDecoder().decode(in.getImage());
+
+            // Genera un nombre único para la imagen (se asume extensión PNG)
+            String fileName = UUID.randomUUID().toString() + ".png";
+
+            // Construye la ruta completa donde se guardará la imagen
+            Path imagePath = Paths.get(uploadDir, "img", "customer", fileName);
+
+            // Asegurarse de que el directorio exista
+            Files.createDirectories(imagePath.getParent());
+
+            // Escribir el archivo en el sistema de archivos
+            Files.write(imagePath, imageBytes);
+
+            ProductImage productImage = new ProductImage();
+            productImage.setProductImage_id(in.getProductImage_id());
+            productImage.setImage("/" + uploadDir + "/img/customer/" + fileName);
+            productImage.setStatus(1); 
+
+            // Guardar la ruta de la imagen
+            repo.save(productImage);
+
+            // Eliminar el prefijo "data:image/png;base64," si existe
+            if (in.getImage().startsWith("data:image")) {
+                int commaIndex = in.getImage().indexOf(",");
+                if (commaIndex != -1)
+                    in.setImage(in.getImage().substring(commaIndex + 1));
+            }
+
+            return new ApiResponse("La imagen del producto ha sido actualizada");
+		} catch (DataAccessException e) {
+            throw new DBAccessException(e);
+		} catch (IOException e) {
+            throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Error al guardar el archivo");
+        }
+	}
+}
+

--- a/src/main/java/com/product/api/service/SvcProductImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImp.java
@@ -62,7 +62,7 @@ public class SvcProductImp implements SvcProduct{
 	 * @return Una respuesta con los datos de un producto específico dado su identificador
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
 	 * @throws ApiException Al encontrar un error en el contenido de:
-	 * 						El identificador del producto
+	 *                      El identificador del producto
 	 */
 	@Override
 	public ResponseEntity<DtoProductOut> getProduct(Integer id) {
@@ -77,12 +77,13 @@ public class SvcProductImp implements SvcProduct{
 
 	/**
      * Crea un producto
+     * @param in objeto de transferencia de un producto
      * @return Una respuesta que indíca el éxito en la operación
      * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
      *                      El GTIN del producto
      *                      El nombre del producto
-	 * 						El identificador de la categoría asociado al producto
+	 *                      El identificador de la categoría asociado al producto
      */
 	@Override
 	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in) {
@@ -104,13 +105,15 @@ public class SvcProductImp implements SvcProduct{
 
 	/**
      * Actualiza un producto
+     * @param in objeto de transferencia de una categoría
+     * @param id identificador del producto
      * @return Una respuesta que indíca el éxito en la operación
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
-	 * 						El identificador del producto
+	 * 				        El identificador del producto
      *                      Campo ya registrado en el GTIN del producto
      *                      Campo ya registrado en el nombre del producto
-	 * 						El identificador de la categoría asociado al producto
+	 * 				        El identificador de la categoría asociado al producto
      */
 	@Override
 	public ResponseEntity<ApiResponse> updateProduct(Integer id, DtoProductIn in) {
@@ -133,6 +136,7 @@ public class SvcProductImp implements SvcProduct{
 
 	/**
      * Habilita un producto
+     * @param id identificador del producto
      * @return Una respuesta que indíca el éxito en la operación
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:
@@ -153,6 +157,7 @@ public class SvcProductImp implements SvcProduct{
 
 	/**
      * Deshabilita un producto
+     * @param id identificador del producto
      * @return Una respuesta que indíca el éxito en la operación
 	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
      * @throws ApiException Al encontrar un error en el contenido de:

--- a/src/main/java/com/product/api/service/SvcProductImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImp.java
@@ -1,8 +1,14 @@
 package com.product.api.service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +20,9 @@ import com.product.api.dto.in.DtoProductIn;
 import com.product.api.dto.out.DtoProductListOut;
 import com.product.api.dto.out.DtoProductOut;
 import com.product.api.entity.Product;
+import com.product.api.entity.ProductImage;
 import com.product.api.repository.RepoProduct;
+import com.product.api.repository.RepoProductImage;
 import com.product.exception.ApiException;
 import com.product.exception.DBAccessException;
 
@@ -29,6 +37,8 @@ import com.product.exception.DBAccessException;
 @Service
 public class SvcProductImp implements SvcProduct{
 
+    private final RepoProductImage repoProductImage;
+
 	/**
 	 * Repositorio para productos
 	 */
@@ -40,6 +50,16 @@ public class SvcProductImp implements SvcProduct{
 	 */
 	@Autowired
 	MapperProduct mapper;
+	
+	/**
+	 * Ruta del directorio para almacenar imagenes
+	 */
+	@Value("${app.upload.dir}")
+	private String uploadDir;
+
+    SvcProductImp(RepoProductImage repoProductImage) {
+        this.repoProductImage = repoProductImage;
+    }
 
 	/**
      * Obtiene una respuesta con todos los productos
@@ -67,9 +87,14 @@ public class SvcProductImp implements SvcProduct{
 	@Override
 	public ResponseEntity<DtoProductOut> getProduct(Integer id) {
 		try {
-			validateProductId(id);
+			DtoProductOut product = repo.getProduct(id);
+			if(product == null)
+				throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
 			
-			return new ResponseEntity<>(null, HttpStatus.OK);
+			String image = readProductImageFile(id);
+			product.setImage(image);
+			
+			return new ResponseEntity<>(product, HttpStatus.OK);
 		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
 		}
@@ -89,7 +114,14 @@ public class SvcProductImp implements SvcProduct{
 	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in) {
 		try {
 			Product product = mapper.fromDto(in);
-			repo.save(product);
+			product = repo.save(product);
+			
+			ProductImage productImage = new ProductImage();
+			productImage.setProduct_id(product.getProduct_id());
+			productImage.setImage("");
+			productImage.setStatus(1);
+			repoProductImage.save(productImage);
+			
 			return new ResponseEntity<>(new ApiResponse("El producto ha sido registrado"), HttpStatus.CREATED);
 		} catch (DataAccessException e) {
 			if (e.getLocalizedMessage().contains("ux_product_gtin"))
@@ -188,6 +220,44 @@ public class SvcProductImp implements SvcProduct{
 				throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
 		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
+		}
+	}
+	
+	/**
+	 * Lee la imagen de un producto y la convierte a Base64
+	 * @param product_id identificador del producto
+	 * @return La imagen del producto en formato Base64, o cadena vacía si no existe
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+	 * @throws ApiException Al encontrar un error al leer el archivo
+	 */
+	private String readProductImageFile(Integer product_id) {
+		try {
+			ProductImage productImage = repoProductImage.findByProductId(product_id);
+			if(productImage == null)
+				return "";
+			
+			String imageUrl = productImage.getImage();
+			
+			// Si la URL comienza con "/" la eliminamos para obtener la ruta relativa
+			if (imageUrl.startsWith("/")) {
+				imageUrl = imageUrl.substring(1);
+			}
+			
+			// Construir el Path
+			Path imagePath = Paths.get(uploadDir, imageUrl);
+			
+			// Verifica que el archivo exista
+			if (!Files.exists(imagePath))
+				return "";
+			
+			// Leer los bytes de la imagen y codificarlos a Base64
+			byte[] imageBytes = Files.readAllBytes(imagePath);
+			return Base64.getEncoder().encodeToString(imageBytes);
+			
+		} catch (DataAccessException e) {
+			throw new DBAccessException(e);
+		} catch (IOException e) {
+			throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Error al leer el archivo");
 		}
 	}
 

--- a/src/main/java/com/product/api/service/SvcProductImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImp.java
@@ -18,43 +18,79 @@ import com.product.api.repository.RepoProduct;
 import com.product.exception.ApiException;
 import com.product.exception.DBAccessException;
 
+/**
+ * Clase de servicio para productos.
+ * 
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.7.0
+ * @beta
+ */
 @Service
 public class SvcProductImp implements SvcProduct{
-	
+
+	/**
+	 * Repositorio para productos
+	 */
 	@Autowired
 	RepoProduct repo;
 	
+	/**
+	 * Convertidor de estructuras especializado en productos
+	 */
 	@Autowired
 	MapperProduct mapper;
 
+	/**
+     * Obtiene una respuesta con todos los productos
+     * @return Una respuesta con todos los productos
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     */
 	@Override
 	public ResponseEntity<List<DtoProductListOut>> getProducts() {
 		try {
 			List<Product> products = repo.findAll();
 			return new ResponseEntity<>(mapper.fromProductList(products), HttpStatus.OK);
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
 		}
 	}
 
+	/**
+	 * Obtiene una respuesta con los datos de un producto específico dado su identificador
+	 * @param id identificador del producto
+	 * @return Una respuesta con los datos de un producto específico dado su identificador
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+	 * @throws ApiException Al encontrar un error en el contenido de:
+	 * 						El identificador del producto
+	 */
 	@Override
 	public ResponseEntity<DtoProductOut> getProduct(Integer id) {
 		try {
 			validateProductId(id);
 			
 			return new ResponseEntity<>(null, HttpStatus.OK);
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
 		}
 	}
 
+	/**
+     * Crea un producto
+     * @return Una respuesta que indíca el éxito en la operación
+     * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El GTIN del producto
+     *                      El nombre del producto
+	 * 						El identificador de la categoría asociado al producto
+     */
 	@Override
 	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in) {
 		try {
 			Product product = mapper.fromDto(in);
 			repo.save(product);
 			return new ResponseEntity<>(new ApiResponse("El producto ha sido registrado"), HttpStatus.CREATED);
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			if (e.getLocalizedMessage().contains("ux_product_gtin"))
 				throw new ApiException(HttpStatus.CONFLICT, "El gtin del producto ya está registrado");
 			if (e.getLocalizedMessage().contains("ux_product_product"))
@@ -66,6 +102,16 @@ public class SvcProductImp implements SvcProduct{
 		}
 	}
 
+	/**
+     * Actualiza un producto
+     * @return Una respuesta que indíca el éxito en la operación
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+	 * 						El identificador del producto
+     *                      Campo ya registrado en el GTIN del producto
+     *                      Campo ya registrado en el nombre del producto
+	 * 						El identificador de la categoría asociado al producto
+     */
 	@Override
 	public ResponseEntity<ApiResponse> updateProduct(Integer id, DtoProductIn in) {
 		try {
@@ -73,7 +119,7 @@ public class SvcProductImp implements SvcProduct{
 			Product product = mapper.fromDto(id, in);
 			repo.save(product);
 			return new ResponseEntity<>(new ApiResponse("El producto ha sido actualizado"), HttpStatus.OK);
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			if (e.getLocalizedMessage().contains("ux_product_gtin"))
 				throw new ApiException(HttpStatus.CONFLICT, "El gtin del producto ya está registrado");
 			if (e.getLocalizedMessage().contains("ux_product_product"))
@@ -85,6 +131,13 @@ public class SvcProductImp implements SvcProduct{
 		}
 	}
 
+	/**
+     * Habilita un producto
+     * @return Una respuesta que indíca el éxito en la operación
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador del producto
+     */
 	@Override
 	public ResponseEntity<ApiResponse> enableProduct(Integer id) {
 		try {
@@ -93,11 +146,18 @@ public class SvcProductImp implements SvcProduct{
 			product.setStatus(1);
 			repo.save(product);
 			return new ResponseEntity<>(new ApiResponse("El producto ha sido activado"), HttpStatus.OK);
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
 		}
 	}
 
+	/**
+     * Deshabilita un producto
+     * @return Una respuesta que indíca el éxito en la operación
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Al encontrar un error en el contenido de:
+     *                      El identificador del producto
+     */
 	@Override
 	public ResponseEntity<ApiResponse> disableProduct(Integer id) {
 		try {
@@ -106,17 +166,22 @@ public class SvcProductImp implements SvcProduct{
 			product.setStatus(0);
 			repo.save(product);
 			return new ResponseEntity<>(new ApiResponse("El producto ha sido desactivado"), HttpStatus.OK);
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
 		}
 	}
 	
+	/**
+     * Valida que el identificador del producto exista
+     * @param id identificador de la categoría a validar
+	 * @throws DBAccessException Al encontrar un error sobre la capa de persistencia
+     * @throws ApiException Si el identificador de la categoría no está registrado
+     */
 	private void validateProductId(Integer id) {
 		try {
-			if(repo.findById(id).isEmpty()) {
+			if (repo.findById(id).isEmpty())
 				throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
-			}
-		}catch (DataAccessException e) {
+		} catch (DataAccessException e) {
 			throw new DBAccessException(e);
 		}
 	}

--- a/src/main/java/com/product/api/service/SvcProductImp.java
+++ b/src/main/java/com/product/api/service/SvcProductImp.java
@@ -1,0 +1,124 @@
+package com.product.api.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.commons.dto.ApiResponse;
+import com.commons.mapper.MapperProduct;
+import com.product.api.dto.in.DtoProductIn;
+import com.product.api.dto.out.DtoProductListOut;
+import com.product.api.dto.out.DtoProductOut;
+import com.product.api.entity.Product;
+import com.product.api.repository.RepoProduct;
+import com.product.exception.ApiException;
+import com.product.exception.DBAccessException;
+
+@Service
+public class SvcProductImp implements SvcProduct{
+	
+	@Autowired
+	RepoProduct repo;
+	
+	@Autowired
+	MapperProduct mapper;
+
+	@Override
+	public ResponseEntity<List<DtoProductListOut>> getProducts() {
+		try {
+			List<Product> products = repo.findAll();
+			return new ResponseEntity<>(mapper.fromProductList(products), HttpStatus.OK);
+		}catch (DataAccessException e) {
+			throw new DBAccessException(e);
+		}
+	}
+
+	@Override
+	public ResponseEntity<DtoProductOut> getProduct(Integer id) {
+		try {
+			validateProductId(id);
+			
+			return new ResponseEntity<>(null, HttpStatus.OK);
+		}catch (DataAccessException e) {
+			throw new DBAccessException(e);
+		}
+	}
+
+	@Override
+	public ResponseEntity<ApiResponse> createProduct(DtoProductIn in) {
+		try {
+			Product product = mapper.fromDto(in);
+			repo.save(product);
+			return new ResponseEntity<>(new ApiResponse("El producto ha sido registrado"), HttpStatus.CREATED);
+		}catch (DataAccessException e) {
+			if (e.getLocalizedMessage().contains("ux_product_gtin"))
+				throw new ApiException(HttpStatus.CONFLICT, "El gtin del producto ya está registrado");
+			if (e.getLocalizedMessage().contains("ux_product_product"))
+				throw new ApiException(HttpStatus.CONFLICT, "El nombre del producto ya está registrado");
+			if (e.getLocalizedMessage().contains("fk_product_category"))
+				throw new ApiException(HttpStatus.NOT_FOUND, "El id de categoría no existe");
+
+			throw new DBAccessException(e);
+		}
+	}
+
+	@Override
+	public ResponseEntity<ApiResponse> updateProduct(Integer id, DtoProductIn in) {
+		try {
+			validateProductId(id);
+			Product product = mapper.fromDto(id, in);
+			repo.save(product);
+			return new ResponseEntity<>(new ApiResponse("El producto ha sido actualizado"), HttpStatus.OK);
+		}catch (DataAccessException e) {
+			if (e.getLocalizedMessage().contains("ux_product_gtin"))
+				throw new ApiException(HttpStatus.CONFLICT, "El gtin del producto ya está registrado");
+			if (e.getLocalizedMessage().contains("ux_product_product"))
+				throw new ApiException(HttpStatus.CONFLICT, "El nombre del producto ya está registrado");
+			if (e.getLocalizedMessage().contains("fk_product_category"))
+				throw new ApiException(HttpStatus.NOT_FOUND, "El id de categoría no existe");
+
+			throw new DBAccessException(e);
+		}
+	}
+
+	@Override
+	public ResponseEntity<ApiResponse> enableProduct(Integer id) {
+		try {
+			validateProductId(id);
+			Product product = repo.findById(id).get();
+			product.setStatus(1);
+			repo.save(product);
+			return new ResponseEntity<>(new ApiResponse("El producto ha sido activado"), HttpStatus.OK);
+		}catch (DataAccessException e) {
+			throw new DBAccessException(e);
+		}
+	}
+
+	@Override
+	public ResponseEntity<ApiResponse> disableProduct(Integer id) {
+		try {
+			validateProductId(id);
+			Product product = repo.findById(id).get();
+			product.setStatus(0);
+			repo.save(product);
+			return new ResponseEntity<>(new ApiResponse("El producto ha sido desactivado"), HttpStatus.OK);
+		}catch (DataAccessException e) {
+			throw new DBAccessException(e);
+		}
+	}
+	
+	private void validateProductId(Integer id) {
+		try {
+			if(repo.findById(id).isEmpty()) {
+				throw new ApiException(HttpStatus.NOT_FOUND, "El id del producto no existe");
+			}
+		}catch (DataAccessException e) {
+			throw new DBAccessException(e);
+		}
+	}
+
+}

--- a/src/main/java/com/product/config/openapi/OpenApiConfig.java
+++ b/src/main/java/com/product/config/openapi/OpenApiConfig.java
@@ -1,0 +1,61 @@
+package com.product.config.openapi;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+
+/**
+ * Clase que define los datos y comportamiento de la documentación a nivel de API
+ * @author Isaac Robledo R
+ * @author Alejandro Sánchez E
+ * @version 0.8.0
+ */
+@Configuration
+public class OpenApiConfig {
+
+	/**
+	 * Regresa una instancia personalizada de OpenAPI
+	 * @return Una instancia personalizada de OpenAPI
+	 */
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.info(new Info()
+			.title("DWB - API Customer")
+			.version("0.8.0")
+			.description("API para la gestión clientes para la tienda en línea FCiencias Store."));
+	}
+
+	/**
+	 * Regresa un ordenador de schemas personalizado
+	 * @return Un ordenador de schemas personalizado
+	 */
+	@Bean
+	public OpenApiCustomizer sortSchemasAlphabetically() {
+		return openApi -> {
+			Components components = openApi.getComponents();
+			if (components != null && components.getSchemas() != null) {
+				Map<String, Schema> sortedSchemas = components.getSchemas().entrySet().stream()
+					.sorted(Map.Entry.comparingByKey())
+					.collect(Collectors.toMap(
+						Map.Entry::getKey,
+						Map.Entry::getValue,
+						(oldValue, newValue) -> oldValue,
+						LinkedHashMap::new
+					));
+				components.setSchemas(sortedSchemas);
+			}
+		};
+	}
+
+}
+

--- a/src/main/java/com/product/config/security/SecurityConfig.java
+++ b/src/main/java/com/product/config/security/SecurityConfig.java
@@ -3,8 +3,6 @@ package com.product.config.security;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -40,15 +38,13 @@ public class SecurityConfig {
 		.authorizeHttpRequests(
 				auth -> auth
                 // Docs and extra
-				.requestMatchers("/error", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs", "/documentation.html", "/actuator/info", "/actuator/health").permitAll()
+				.requestMatchers("/error", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**", "/documentation.html").permitAll()
                 // Category
-				.requestMatchers(HttpMethod.GET, "/category/active").hasAnyAuthority("ADMIN", "CUSTOMER")
-				.requestMatchers("/category/**").hasAuthority("ADMIN")
-                // Customer
-                .requestMatchers(HttpMethod.GET, "/customer/*").hasAnyAuthority("ADMIN", "CUSTOMER")
-                .requestMatchers("/customer/**").hasAuthority("ADMIN")
-                // Customer images
-                .requestMatchers("/customer-image/**").hasAnyAuthority("ADMIN", "CUSTOMER")
+				.requestMatchers("/category/**").permitAll()
+                // Product
+				.requestMatchers("/product/**").permitAll()
+                // Product images
+                .requestMatchers("/product-image/**").permitAll()
 		)
 		.cors(cors -> cors.configurationSource(corsConfig))
 		.httpBasic(AbstractHttpConfigurer::disable)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,6 @@ springdoc.api-docs.path=/api-docs
 
 # Método de ordenamiento de operaciones
 springdoc.swagger-ui.operationsSorter=method
+
+# Ruta del directorio para almacenar imagenes de producto
+app.upload.dir=uploads

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,8 +19,14 @@ springdoc.swagger-ui.path=/documentation.html
 # Path para acceso a documentación de API
 springdoc.api-docs.path=/api-docs
 
+# Método de ordenamiento de etiquetas
+springdoc.swagger-ui.tags-sorter=alpha
+
 # Método de ordenamiento de operaciones
 springdoc.swagger-ui.operationsSorter=method
+
+# Tipo de expansión a operaciones al iniciar
+springdoc.swagger-ui.doc-expansion=none
 
 # Ruta del directorio para almacenar imagenes de producto
 app.upload.dir=uploads


### PR DESCRIPTION
La documentación de `swagger` se hizo **conforme se avanzó** en las prácticas.
Solo *se agregó la instancia* que customiza la OpenAPI con el customizador que *ordena schemas*.
Se agregó / modificó el `application.properties` con los elementos faltantes.

Se puede acceder desde la dirección [`localhost:8080/documentacion.html`](localhost:8080/documentacion.html) .

Revisado por @CCWebi y @Alejandro-Estrada-1 


